### PR TITLE
added navigation to workspace once data is uploaded and fixed type is…

### DIFF
--- a/src/components/DataManagerApp/DataImportView/DatasetUploadForm/index.tsx
+++ b/src/components/DataManagerApp/DataImportView/DatasetUploadForm/index.tsx
@@ -30,7 +30,7 @@ type Props = {
   rows: RawDataRecordRow[];
   defaultName: string;
   fields: readonly LocalDatasetField[];
-  additionalDatasetSaveCallback?: (
+  additionalDatasetSaveCallback: (
     values: DatasetUploadForm,
   ) => Promise<LocalDataset>;
   disableSubmit?: boolean;
@@ -53,10 +53,6 @@ export function DatasetUploadForm({
     unknown
   >({
     mutationFn: async (values: DatasetUploadForm) => {
-      if (!additionalDatasetSaveCallback) {
-        throw new Error("No dataset save callback provided");
-      }
-
       const savedDataset = await additionalDatasetSaveCallback(values);
 
       return savedDataset;

--- a/src/components/DataManagerApp/DataImportView/DatasetUploadForm/index.tsx
+++ b/src/components/DataManagerApp/DataImportView/DatasetUploadForm/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Stack, TextInput, Title } from "@mantine/core";
 import { useForm } from "@mantine/form";
-import { useNavigate } from "@tanstack/react-router";
+import { invariant, useNavigate } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { AppConfig } from "@/config/AppConfig";
 import { AppLinks } from "@/config/AppLinks";
@@ -30,7 +30,7 @@ type Props = {
   rows: RawDataRecordRow[];
   defaultName: string;
   fields: readonly LocalDatasetField[];
-  additionalDatasetSaveCallback: (
+  additionalDatasetSaveCallback?: (
     values: DatasetUploadForm,
   ) => Promise<LocalDataset>;
   disableSubmit?: boolean;
@@ -53,6 +53,11 @@ export function DatasetUploadForm({
     unknown
   >({
     mutationFn: async (values: DatasetUploadForm) => {
+      invariant(
+        additionalDatasetSaveCallback,
+        "No dataset save callback provided",
+      );
+
       const savedDataset = await additionalDatasetSaveCallback(values);
 
       return savedDataset;

--- a/src/components/DataManagerApp/DataImportView/DatasetUploadForm/index.tsx
+++ b/src/components/DataManagerApp/DataImportView/DatasetUploadForm/index.tsx
@@ -1,7 +1,10 @@
 import { Button, Stack, TextInput, Title } from "@mantine/core";
 import { useForm } from "@mantine/form";
+import { useNavigate } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { AppConfig } from "@/config/AppConfig";
+import { AppLinks } from "@/config/AppLinks";
+import { useCurrentWorkspace } from "@/hooks/workspaces/useCurrentWorkspace";
 import { useMutation } from "@/lib/hooks/query/useMutation";
 import { RawDataRecordRow } from "@/lib/types/common";
 import { DataGrid } from "@/lib/ui/data-viz/DataGrid";
@@ -9,6 +12,7 @@ import { notifyError } from "@/lib/ui/notifications/notifyError";
 import { notifySuccess } from "@/lib/ui/notifications/notifySuccess";
 import { getProp } from "@/lib/utils/objects/higherOrderFuncs";
 import { LocalDatasetField } from "@/models/LocalDataset/LocalDatasetField/types";
+import { LocalDataset } from "@/models/LocalDataset/types";
 
 export type DatasetUploadForm = {
   name: string;
@@ -28,7 +32,7 @@ type Props = {
   fields: readonly LocalDatasetField[];
   additionalDatasetSaveCallback?: (
     values: DatasetUploadForm,
-  ) => void | Promise<void>;
+  ) => Promise<LocalDataset>;
   disableSubmit?: boolean;
 };
 
@@ -39,16 +43,45 @@ export function DatasetUploadForm({
   additionalDatasetSaveCallback,
   disableSubmit,
 }: Props): JSX.Element {
+  const navigate = useNavigate();
+  const workspace = useCurrentWorkspace();
+
   // TODO(jpsyx): add this back once we have a DatasetClient
-  const [saveDataset, isSavePending] = useMutation({
+  const [saveDataset, isSavePending] = useMutation<
+    LocalDataset,
+    DatasetUploadForm,
+    unknown
+  >({
     mutationFn: async (values: DatasetUploadForm) => {
-      await additionalDatasetSaveCallback?.(values);
+      if (!additionalDatasetSaveCallback) {
+        throw new Error("No dataset save callback provided");
+      }
+
+      const savedDataset = await additionalDatasetSaveCallback(values);
+
+      return savedDataset;
     },
-    onSuccess: () => {
+    onSuccess: async (savedDataset) => {
+      if (!savedDataset?.id) {
+        notifyError({
+          title: "Routing failed",
+          message: "No dataset ID returned.",
+        });
+        return;
+      }
+
       notifySuccess({
         title: "Dataset saved",
-        message: "Dataset saved successfully",
+        message: `Dataset "${savedDataset.name}" saved successfully`,
       });
+
+      navigate(
+        AppLinks.dataManagerDatasetView({
+          workspaceSlug: workspace.slug,
+          datasetId: savedDataset.id,
+          datasetName: savedDataset.name,
+        }),
+      );
     },
     onError: () => {
       notifyError({

--- a/src/components/DataManagerApp/DataImportView/ManualUploadView/index.tsx
+++ b/src/components/DataManagerApp/DataImportView/ManualUploadView/index.tsx
@@ -1,6 +1,7 @@
 import { Box, BoxProps, Stack } from "@mantine/core";
 import { Dropzone, FileWithPath } from "@mantine/dropzone";
 import { IconPhoto, IconUpload, IconX } from "@tabler/icons-react";
+import { invariant } from "@tanstack/react-router";
 import { useCurrentWorkspace } from "@/hooks/workspaces/useCurrentWorkspace";
 import { MIMEType } from "@/lib/types/common";
 import { notifyError } from "@/lib/ui/notifications/notifyError";
@@ -30,13 +31,7 @@ export function ManualUploadView({ ...props }: Props): JSX.Element {
   const saveLocalDataset = async (
     values: DatasetUploadForm,
   ): Promise<LocalDataset> => {
-    if (!csv || !fileMetadata) {
-      notifyError({
-        title: "No file selected",
-        message: "Please select a file to import",
-      });
-      throw new Error("No file selected");
-    }
+    invariant(csv && fileMetadata, "CSV or metadata missing");
     const dataset = makeLocalDataset({
       workspaceId: workspace.id,
       name: values.name,

--- a/src/components/DataManagerApp/DataImportView/ManualUploadView/index.tsx
+++ b/src/components/DataManagerApp/DataImportView/ManualUploadView/index.tsx
@@ -6,6 +6,7 @@ import { MIMEType } from "@/lib/types/common";
 import { notifyError } from "@/lib/ui/notifications/notifyError";
 import { FileUploadField } from "@/lib/ui/singleton-forms/FileUploadField";
 import { LocalDatasetClient } from "@/models/LocalDataset/LocalDatasetClient";
+import { LocalDataset } from "@/models/LocalDataset/types";
 import { makeLocalDataset } from "@/models/LocalDataset/utils";
 import { useCSVParser } from "../../hooks/useCSVParser";
 import { DatasetUploadForm } from "../DatasetUploadForm";
@@ -26,12 +27,15 @@ export function ManualUploadView({ ...props }: Props): JSX.Element {
     queryToInvalidate: LocalDatasetClient.QueryKeys.getAll(),
   });
 
-  const saveLocalDataset = async (values: DatasetUploadForm) => {
+  const saveLocalDataset = async (
+    values: DatasetUploadForm,
+  ): Promise<LocalDataset> => {
     if (!csv || !fileMetadata) {
-      return notifyError({
+      notifyError({
         title: "No file selected",
         message: "Please select a file to import",
       });
+      throw new Error("No file selected");
     }
     const dataset = makeLocalDataset({
       workspaceId: workspace.id,
@@ -43,7 +47,7 @@ export function ManualUploadView({ ...props }: Props): JSX.Element {
       data: csv.data,
       fields,
     });
-    const savePromise = new Promise<void>((resolve) => {
+    await new Promise<void>((resolve) => {
       _saveLocalDataset(
         { data: dataset },
         {
@@ -53,7 +57,7 @@ export function ManualUploadView({ ...props }: Props): JSX.Element {
         },
       );
     });
-    await savePromise;
+    return dataset;
   };
 
   return (

--- a/src/lib/utils/invariant.ts
+++ b/src/lib/utils/invariant.ts
@@ -1,0 +1,8 @@
+export function invariant(
+  condition: unknown,
+  message: string,
+): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}


### PR DESCRIPTION
Summary:

Fixed navigation after dataset upload using AppLinks.dataManagerDatasetView for type-safe routing.

Removed unused import of DatasetDetailRoute and related debug logs.

Cleaned up outdated comments.

Minor refactor in ManualUploadView to improve naming consistency for dataset insertion logic.

This ensures reliable routing to dataset detail pages and simplifies route management going forward.