### PR TITLE
Feat/add order by option to the data explorer

### DIFF
--- a/src/clients/LocalDatasetQueryClient.ts
+++ b/src/clients/LocalDatasetQueryClient.ts
@@ -30,6 +30,8 @@ export type LocalQueryConfig = {
   datasetId: LocalDatasetId;
   selectFields: readonly LocalDatasetField[];
   groupByFields: readonly LocalDatasetField[];
+  orderByField?: LocalDatasetField | undefined;
+  orderByDirection?: "asc" | "desc";
 
   /**
    * Aggregations to apply to the selected fields.
@@ -232,6 +234,8 @@ class LocalDatasetQueryClientImpl {
     groupByFields,
     aggregations,
     datasetId,
+    orderByField,
+    orderByDirection,
   }: LocalQueryConfig): Promise<LocalQueryResultData> {
     const selectFieldNames = selectFields.map(getProp("name"));
     const groupByFieldNames = groupByFields.map(getProp("name"));
@@ -249,6 +253,10 @@ class LocalDatasetQueryClientImpl {
       let query = sql.select(...fieldNamesWithoutAggregations).from(tableName);
       if (groupByFieldNames.length > 0) {
         query = query.groupBy(...groupByFieldNames);
+      }
+
+      if (orderByField && orderByDirection) {
+        query = query.orderBy(orderByField.name, orderByDirection);
       }
 
       // apply aggregations

--- a/src/components/DataExplorerApp/QueryForm.tsx
+++ b/src/components/DataExplorerApp/QueryForm.tsx
@@ -15,6 +15,11 @@ import { FieldSelect } from "./FieldSelect";
 const HIDE_WHERE = true;
 const HIDE_LIMIT = true;
 
+const orderOptions = [
+  { value: "asc", label: "Ascending" },
+  { value: "desc", label: "Descending" },
+] as const;
+
 type Direction = "asc" | "desc";
 
 type Props = {
@@ -23,7 +28,7 @@ type Props = {
   selectedDatasetId: LocalDatasetId | undefined;
   selectedFields: readonly LocalDatasetField[];
   orderByField: LocalDatasetField | undefined;
-  orderByDirection: "asc" | "desc";
+  orderByDirection: Direction;
   onAggregationsChange: (
     newAggregations: Record<string, QueryAggregationType>,
   ) => void;
@@ -139,14 +144,11 @@ export function QueryForm({
         <Select
           label="Order by"
           placeholder="Select order"
-          data={[
-            { value: "asc", label: "Ascending" },
-            { value: "desc", label: "Descending" },
-          ]}
+          data={orderOptions}
           value={orderByDirection}
           clearable={false}
           onChange={(value) => {
-            return onOrderByDirectionChange(value as Direction);
+            onOrderByDirectionChange(value as Direction);
           }}
         />
 

--- a/src/components/DataExplorerApp/QueryForm.tsx
+++ b/src/components/DataExplorerApp/QueryForm.tsx
@@ -15,6 +15,8 @@ import { FieldSelect } from "./FieldSelect";
 const HIDE_WHERE = true;
 const HIDE_LIMIT = true;
 
+type Direction = "asc" | "desc";
+
 type Props = {
   errorMessage: string | undefined;
   aggregations: Record<string, QueryAggregationType>;
@@ -42,9 +44,9 @@ export function QueryForm({
   onFromDatasetChange,
   onSelectFieldsChange,
   onGroupByChange,
+  orderByDirection,
   onOrderByFieldChange,
   onOrderByDirectionChange,
-  orderByDirection,
 }: Props): JSX.Element {
   return (
     <form>
@@ -130,7 +132,7 @@ export function QueryForm({
             const selected = selectedFields.find((f) => {
               return f.name === fieldName;
             });
-            onOrderByFieldChange(selected); // not [selected]
+            onOrderByFieldChange(selected);
           }}
         />
 
@@ -142,10 +144,9 @@ export function QueryForm({
             { value: "desc", label: "Descending" },
           ]}
           value={orderByDirection}
+          clearable={false}
           onChange={(value) => {
-            if (value === "asc" || value === "desc") {
-              onOrderByDirectionChange(value);
-            }
+            return onOrderByDirectionChange(value as Direction);
           }}
         />
 

--- a/src/components/DataExplorerApp/QueryForm.tsx
+++ b/src/components/DataExplorerApp/QueryForm.tsx
@@ -1,4 +1,4 @@
-import { Fieldset, Stack, Text } from "@mantine/core";
+import { Fieldset, Select, Stack, Text } from "@mantine/core";
 import { QueryAggregationType } from "@/clients/LocalDatasetQueryClient";
 import { DangerText } from "@/lib/ui/Text/DangerText";
 import { difference } from "@/lib/utils/arrays";
@@ -13,7 +13,6 @@ import { AggregationSelect } from "./AggregationSelect";
 import { FieldSelect } from "./FieldSelect";
 
 const HIDE_WHERE = true;
-const HIDE_ORDER_BY = true;
 const HIDE_LIMIT = true;
 
 type Props = {
@@ -21,12 +20,15 @@ type Props = {
   aggregations: Record<string, QueryAggregationType>;
   selectedDatasetId: LocalDatasetId | undefined;
   selectedFields: readonly LocalDatasetField[];
+  orderByDirection: "asc" | "desc";
   onAggregationsChange: (
     newAggregations: Record<string, QueryAggregationType>,
   ) => void;
   onFromDatasetChange: (datasetId: LocalDatasetId | undefined) => void;
   onSelectFieldsChange: (fields: readonly LocalDatasetField[]) => void;
   onGroupByChange: (fields: readonly LocalDatasetField[]) => void;
+  onOrderByFieldChange: (fields: readonly LocalDatasetField[]) => void;
+  onOrderByDirectionChange: (value: "asc" | "desc") => void;
 };
 
 /**
@@ -44,6 +46,9 @@ export function QueryForm({
   onFromDatasetChange,
   onSelectFieldsChange,
   onGroupByChange,
+  orderByDirection,
+  onOrderByFieldChange,
+  onOrderByDirectionChange,
 }: Props): JSX.Element {
   return (
     <form>
@@ -119,7 +124,32 @@ export function QueryForm({
           onChange={onGroupByChange}
           datasetId={selectedDatasetId}
         />
-        {HIDE_ORDER_BY ? null : <Text>Order by (fields dropdown)</Text>}
+        <FieldSelect
+          label="Field"
+          placeholder="Select field"
+          onChange={(fields) => {
+            const firstField = fields[0];
+            if (firstField) {
+              onOrderByFieldChange([firstField]);
+            }
+          }}
+          datasetId={selectedDatasetId}
+        />
+        <Select
+          label="Order by"
+          placeholder="Select order"
+          data={[
+            { value: "asc", label: "Ascending" },
+            { value: "desc", label: "Descending" },
+          ]}
+          value={orderByDirection}
+          onChange={(value) => {
+            if (value === "asc" || value === "desc") {
+              onOrderByDirectionChange(value);
+            }
+          }}
+        />
+
         {HIDE_LIMIT ? null : <Text>Limit (number)</Text>}
         {errorMessage ?
           <DangerText>{errorMessage}</DangerText>

--- a/src/components/DataExplorerApp/QueryForm.tsx
+++ b/src/components/DataExplorerApp/QueryForm.tsx
@@ -20,6 +20,7 @@ type Props = {
   aggregations: Record<string, QueryAggregationType>;
   selectedDatasetId: LocalDatasetId | undefined;
   selectedFields: readonly LocalDatasetField[];
+  orderByField: LocalDatasetField | undefined;
   orderByDirection: "asc" | "desc";
   onAggregationsChange: (
     newAggregations: Record<string, QueryAggregationType>,
@@ -27,28 +28,23 @@ type Props = {
   onFromDatasetChange: (datasetId: LocalDatasetId | undefined) => void;
   onSelectFieldsChange: (fields: readonly LocalDatasetField[]) => void;
   onGroupByChange: (fields: readonly LocalDatasetField[]) => void;
-  onOrderByFieldChange: (fields: readonly LocalDatasetField[]) => void;
+  onOrderByFieldChange: (field: LocalDatasetField | undefined) => void;
   onOrderByDirectionChange: (value: "asc" | "desc") => void;
 };
 
-/**
- * This is a presentational component that just receives QueryForm props and
- * renders the UI. It does not handle any business logic, such as checking
- * if the query is valid or running the query. The parent component should
- * handle that logic.
- */
 export function QueryForm({
   errorMessage,
   aggregations,
   selectedFields,
   selectedDatasetId,
+  orderByField,
   onAggregationsChange,
   onFromDatasetChange,
   onSelectFieldsChange,
   onGroupByChange,
-  orderByDirection,
   onOrderByFieldChange,
   onOrderByDirectionChange,
+  orderByDirection,
 }: Props): JSX.Element {
   return (
     <form>
@@ -66,9 +62,6 @@ export function QueryForm({
           onChange={(fields) => {
             onSelectFieldsChange(fields);
 
-            // Remove the aggregations for any fields that are no longer
-            // selected, and add a default "none" aggregation for any
-            // new fields that just got added
             const prevAggregations = aggregations;
             const incomingFieldNames = fields.map(getProp("name"));
             const prevFieldNames = objectKeys(prevAggregations);
@@ -94,9 +87,7 @@ export function QueryForm({
         {selectedFields.length > 0 ?
           <Fieldset
             legend="Aggregations"
-            style={{
-              backgroundColor: "rgba(255, 255, 255, 0.4)",
-            }}
+            style={{ backgroundColor: "rgba(255, 255, 255, 0.4)" }}
           >
             {selectedFields.map((field) => {
               return (
@@ -124,17 +115,25 @@ export function QueryForm({
           onChange={onGroupByChange}
           datasetId={selectedDatasetId}
         />
-        <FieldSelect
-          label="Field"
+
+        <Select
+          label="Select field"
           placeholder="Select field"
-          onChange={(fields) => {
-            const firstField = fields[0];
-            if (firstField) {
-              onOrderByFieldChange([firstField]);
-            }
+          data={selectedFields.map((f) => {
+            return {
+              value: f.name,
+              label: f.name,
+            };
+          })}
+          value={orderByField?.name}
+          onChange={(fieldName) => {
+            const selected = selectedFields.find((f) => {
+              return f.name === fieldName;
+            });
+            onOrderByFieldChange(selected); // not [selected]
           }}
-          datasetId={selectedDatasetId}
         />
+
         <Select
           label="Order by"
           placeholder="Select order"

--- a/src/components/DataExplorerApp/index.tsx
+++ b/src/components/DataExplorerApp/index.tsx
@@ -33,6 +33,12 @@ export function DataExplorerApp(): JSX.Element {
   const [selectedGroupByFields, setSelectedGroupByFields] = useState<
     readonly LocalDatasetField[]
   >([]);
+  const [orderByField, setOrderByField] = useState<
+    readonly LocalDatasetField[]
+  >([]);
+  const [orderByDirection, setOrderByDirection] = useState<"asc" | "desc">(
+    "asc",
+  );
   const [vizConfig, setVizConfig] = useState<VizConfig>(() => {
     return makeDefaultVizConfig("table");
   });
@@ -124,6 +130,9 @@ export function DataExplorerApp(): JSX.Element {
           onFromDatasetChange={setSelectedDatasetId}
           onSelectFieldsChange={setSelectedFields}
           onGroupByChange={setSelectedGroupByFields}
+          orderByDirection={orderByDirection}
+          onOrderByFieldChange={setOrderByField}
+          onOrderByDirectionChange={setOrderByDirection}
           errorMessage={errorMessage}
         />
         <VizSettingsForm

--- a/src/components/DataExplorerApp/index.tsx
+++ b/src/components/DataExplorerApp/index.tsx
@@ -34,8 +34,9 @@ export function DataExplorerApp(): JSX.Element {
     readonly LocalDatasetField[]
   >([]);
   const [orderByField, setOrderByField] = useState<
-    readonly LocalDatasetField[]
-  >([]);
+    LocalDatasetField | undefined
+  >(undefined);
+
   const [orderByDirection, setOrderByDirection] = useState<"asc" | "desc">(
     "asc",
   );
@@ -102,6 +103,8 @@ export function DataExplorerApp(): JSX.Element {
     datasetId: selectedDatasetId,
     selectFields: selectedFields,
     groupByFields: selectedGroupByFields,
+    orderByField,
+    orderByDirection,
   });
 
   const { fields, data } = useMemo(() => {
@@ -126,12 +129,13 @@ export function DataExplorerApp(): JSX.Element {
           aggregations={aggregations}
           selectedDatasetId={selectedDatasetId}
           selectedFields={selectedFields}
+          orderByField={orderByField}
           onAggregationsChange={setAggregations}
           onFromDatasetChange={setSelectedDatasetId}
           onSelectFieldsChange={setSelectedFields}
           onGroupByChange={setSelectedGroupByFields}
-          orderByDirection={orderByDirection}
           onOrderByFieldChange={setOrderByField}
+          orderByDirection={orderByDirection}
           onOrderByDirectionChange={setOrderByDirection}
           errorMessage={errorMessage}
         />

--- a/src/components/DataExplorerApp/useDataQuery.tsx
+++ b/src/components/DataExplorerApp/useDataQuery.tsx
@@ -14,6 +14,8 @@ export function useDataQuery({
   enabled,
   selectFields = [],
   groupByFields = [],
+  orderByField,
+  orderByDirection,
 }: Partial<LocalQueryConfig> & {
   enabled: boolean;
 }): UseQueryResultTuple<LocalQueryResultData> {
@@ -41,6 +43,9 @@ export function useDataQuery({
       ...sortedAggregations,
       "groupBy",
       ...sortedGroupByNames,
+      "orderBy",
+      orderByField?.name,
+      orderByDirection,
     ],
 
     queryFn: async () => {
@@ -54,6 +59,8 @@ export function useDataQuery({
           aggregations,
           selectFields,
           groupByFields,
+          orderByField,
+          orderByDirection,
         });
       }
       return { fields: [], data: [] };

--- a/src/lib/ui/ObjectDescriptionList/types.ts
+++ b/src/lib/ui/ObjectDescriptionList/types.ts
@@ -1,5 +1,4 @@
 import { ReactNode } from "react";
-import { UnionToTuple } from "type-fest";
 import { StringKeyOf } from "@/lib/types/utilityTypes";
 
 /** A non-recursive value */
@@ -57,7 +56,7 @@ export type PrimitiveValueRenderOptions = {
   dateFormat?: string;
 };
 
-export const PRIMITIVE_VALUE_RENDER_OPTIONS_KEYS: UnionToTuple<
+export const PRIMITIVE_VALUE_RENDER_OPTIONS_KEYS: ReadonlyArray<
   keyof PrimitiveValueRenderOptions
 > = [
   "renderEmptyString",


### PR DESCRIPTION
New orderByField and orderByDirection controls in QueryForm

🧪 How to Test


1. - Select a dataset and some fields

2. - Choose a field from the Order By Field dropdown

3. - Set ascending or descending order

4. - Run query — results should be sorted accordingly


Ticket: https://github.com/AvandarLabs/avandar/issues/9

https://www.loom.com/share/3beba4a087624275a13b680740e7bf9a?sid=2dc662ae-135f-433c-8195-6acde5546cc5