### PR TITLE
Chore/long workspace names should fit

### DIFF
--- a/src/lib/ui/AppShell/index.tsx
+++ b/src/lib/ui/AppShell/index.tsx
@@ -187,14 +187,14 @@ export function AppShell({
             />
             <Menu shadow="md" width={200}>
               <Menu.Target>
-                <UnstyledButton>
-                  <Group wrap="nowrap" gap="xs">
+                <UnstyledButton className="w-full text-left">
+                  <div className="flex w-full items-center justify-between gap-2">
                     {logo}
-                    <Title order={2} size="md" textWrap="wrap">
+                    <span className="flex-1 break-words text-base font-medium leading-tight">
                       {title ?? AppConfig.appName}
-                    </Title>
-                    <IconChevronDown size={18} />
-                  </Group>
+                    </span>
+                    <IconChevronDown size={18} className="min-h-4 min-w-4" />
+                  </div>
                 </UnstyledButton>
               </Menu.Target>
               <Menu.Dropdown style={{ width: "max-content", minWidth: 200 }}>

--- a/src/lib/ui/AppShell/index.tsx
+++ b/src/lib/ui/AppShell/index.tsx
@@ -190,7 +190,7 @@ export function AppShell({
                 <UnstyledButton>
                   <Group wrap="nowrap" gap="xs">
                     {logo}
-                    <Title order={2} size="md" textWrap="nowrap">
+                    <Title order={2} size="md" textWrap="wrap">
                       {title ?? AppConfig.appName}
                     </Title>
                     <IconChevronDown size={18} />


### PR DESCRIPTION
Added `wrap` option in css for long workspace names in AppShell.

Ticket: https://github.com/AvandarLabs/avandar/issues/67

<img width="1574" height="879" alt="Screenshot 2025-08-07 at 2 45 12 PM" src="https://github.com/user-attachments/assets/8472f4f0-a5ad-479f-8859-2d9670e1519e" />
