### PR TITLE
Chore/date needs proper formatting in data explorer

### DIFF
--- a/src/components/DataExplorerApp/VisualizationContainer.tsx
+++ b/src/components/DataExplorerApp/VisualizationContainer.tsx
@@ -62,9 +62,6 @@ export function VisualizationContainer({
     );
   }, [fields, data]);
 
-  console.debug("fields", fields);
-  console.debug("dateColumns", Array.from(dateColumns));
-
   return match(vizConfig)
     .with({ type: "table" }, () => {
       return (

--- a/src/components/DataExplorerApp/VisualizationContainer.tsx
+++ b/src/components/DataExplorerApp/VisualizationContainer.tsx
@@ -6,6 +6,10 @@ import { UnknownDataFrame } from "@/lib/types/common";
 import { BarChart } from "@/lib/ui/data-viz/BarChart";
 import { DataGrid } from "@/lib/ui/data-viz/DataGrid";
 import { DangerText } from "@/lib/ui/Text/DangerText";
+import {
+  isEpochMs,
+  isIsoDateString,
+} from "@/lib/utils/formatters/formatDateish";
 import { getProp } from "@/lib/utils/objects/higherOrderFuncs";
 import { VizConfig } from "./VizSettingsForm/makeDefaultVizConfig";
 
@@ -41,9 +45,35 @@ export function VisualizationContainer({
     return fields.map(getProp("name"));
   }, [fields]);
 
+  const dateColumns = useMemo(() => {
+    return new Set(
+      fields
+        .filter((f) => {
+          const sampleVal = data[0]?.[f.name];
+          return (
+            f.dataType === "date" ||
+            isIsoDateString(sampleVal) ||
+            isEpochMs(sampleVal)
+          );
+        })
+        .map((f) => {
+          return f.name;
+        }),
+    );
+  }, [fields, data]);
+
+  console.debug("fields", fields);
+  console.debug("dateColumns", Array.from(dateColumns));
+
   return match(vizConfig)
     .with({ type: "table" }, () => {
-      return <DataGrid columnNames={fieldNames} data={data} />;
+      return (
+        <DataGrid
+          columnNames={fieldNames}
+          data={data}
+          dateColumns={dateColumns}
+        />
+      );
     })
     .with({ type: "bar" }, (config) => {
       const {

--- a/src/lib/ui/ObjectDescriptionList/PrimitiveValueItem.tsx
+++ b/src/lib/ui/ObjectDescriptionList/PrimitiveValueItem.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@mantine/core";
-import dayjs from "dayjs";
+import { formatDateish } from "@/lib/utils/formatters/formatDateish";
 import { isDate } from "@/lib/utils/guards";
 import { isStringOrNumber } from "./guards";
 import type { PrimitiveValue, PrimitiveValueRenderOptions } from "./types";
@@ -73,14 +73,7 @@ export function PrimitiveValueItem<T extends PrimitiveValue>({
   }
 
   if (isDate(value)) {
-    // TODO(jpsyx): add options to format the date
-    return (
-      <Text span>
-        {dateFormat ?
-          dayjs(value).format(dateFormat)
-        : value.toLocaleDateString()}
-      </Text>
-    );
+    return <Text span>{formatDateish(value, dateFormat ?? "YYYY-MM-DD")}</Text>;
   }
 
   // fallback, just cast to string

--- a/src/lib/ui/data-viz/DataGrid.tsx
+++ b/src/lib/ui/data-viz/DataGrid.tsx
@@ -3,6 +3,7 @@ import { AgGridReact } from "ag-grid-react";
 import { useMemo } from "react";
 import { Writable } from "type-fest";
 import { UnknownDataFrame } from "@/lib/types/common";
+import { formatDateish } from "@/lib/utils/formatters/formatDateish";
 
 type Props = {
   columnNames: readonly string[];
@@ -14,11 +15,13 @@ type Props = {
    */
   data: UnknownDataFrame;
   height?: number;
+  dateColumns?: ReadonlySet<string>;
 };
 
 export function DataGrid({
   columnNames,
   data,
+  dateColumns,
   height = 500,
 }: Props): JSX.Element {
   const columnDefs = useMemo(() => {
@@ -26,9 +29,15 @@ export function DataGrid({
       return {
         field: field,
         headerName: field,
+        valueFormatter:
+          dateColumns?.has(field) ?
+            (p: { value: unknown }) => {
+              return formatDateish(p.value);
+            }
+          : undefined,
       };
     });
-  }, [columnNames]);
+  }, [columnNames, dateColumns]);
 
   // AgGrid will fill the size of the parent container
   return (

--- a/src/lib/utils/formatters/formatDateish.ts
+++ b/src/lib/utils/formatters/formatDateish.ts
@@ -1,0 +1,19 @@
+import dayjs from "dayjs";
+
+/** ISO-ish string like 2024-01-21T... */
+export function isIsoDateString(v: unknown): v is string {
+  return typeof v === "string" && /^\d{4}-\d{2}-\d{2}T/.test(v);
+}
+
+/** Epoch millis (very rough heuristic) */
+export function isEpochMs(v: unknown): v is number {
+  return typeof v === "number" && v > 1e12;
+}
+
+/** Return YYYY-MM-DD for ISO strings or epoch ms; else String(v). */
+export function formatDateish(v: unknown, fmt = "YYYY-MM-DD"): string {
+  if (v == null) return "";
+  if (isEpochMs(v)) return dayjs(v).format(fmt);
+  if (isIsoDateString(v)) return dayjs(v).format(fmt);
+  return String(v);
+}


### PR DESCRIPTION
Fixes inconsistent date rendering in Data Explorer.

Detects date columns via dataType, ISO string, or epoch ms.

Centralizes formatting with formatDateish for both DataGrid and PrimitiveValueItem.

Now matches Data Manager’s YYYY-MM-DD display without touching runQuery.

Ticket# - https://github.com/AvandarLabs/avandar/issues/71

|
<img width="1725" height="679" alt="Screenshot 2025-08-08 at 12 30 06 PM" src="https://github.com/user-attachments/assets/5599b393-d16e-4937-87e8-d4ca67eed128" />
