### PR TITLE
added pencil icon for datasets

### DIFF
--- a/src/components/DataManagerApp/DatasetMetaView/EditDatasetView.tsx
+++ b/src/components/DataManagerApp/DatasetMetaView/EditDatasetView.tsx
@@ -1,4 +1,3 @@
-import { Box } from "@mantine/core";
 import { notifyError } from "@/lib/ui/notifications/notifyError";
 import { notifySuccess } from "@/lib/ui/notifications/notifySuccess";
 import { InputTextField } from "@/lib/ui/singleton-forms/InputTextField";
@@ -21,23 +20,21 @@ export function EditDatasetView({ dataset }: Props): JSX.Element {
   });
 
   return (
-    <Box mt="md" mb="xl">
-      <InputTextField
-        defaultValue={dataset.name}
-        label="Dataset Name"
-        minLength={2}
-        inputWidth={300}
-        required
-        showSubmitButton
-        submitButtonLabel="Save"
-        isSubmitting={isUpdatePending}
-        onSubmit={(newName) => {
-          return updateDataset({
-            id: dataset.id,
-            data: { name: newName },
-          });
-        }}
-      />
-    </Box>
+    <InputTextField
+      defaultValue={dataset.name}
+      required
+      hideLabel
+      minLength={2}
+      inputWidth={300}
+      showSubmitButton
+      submitButtonLabel="Save"
+      isSubmitting={isUpdatePending}
+      onSubmit={(newName) => {
+        return updateDataset({
+          id: dataset.id,
+          data: { name: newName },
+        });
+      }}
+    />
   );
 }

--- a/src/components/DataManagerApp/DatasetMetaView/index.tsx
+++ b/src/components/DataManagerApp/DatasetMetaView/index.tsx
@@ -1,9 +1,12 @@
 import {
+  ActionIcon,
   Button,
   Container,
   FloatingIndicator,
+  Group,
   Loader,
   MantineTheme,
+  Paper,
   Stack,
   Tabs,
   Text,
@@ -11,7 +14,7 @@ import {
 } from "@mantine/core";
 import { modals } from "@mantine/modals";
 import { notifications } from "@mantine/notifications";
-import { IconPencil } from "@tabler/icons-react";
+import { IconPencil, IconX } from "@tabler/icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
 import { AppLinks } from "@/config/AppLinks";
@@ -19,7 +22,6 @@ import { useCurrentWorkspace } from "@/hooks/workspaces/useCurrentWorkspace";
 import { DataGrid } from "@/lib/ui/data-viz/DataGrid";
 import { ObjectDescriptionList } from "@/lib/ui/ObjectDescriptionList";
 import { ChildRenderOptionsMap } from "@/lib/ui/ObjectDescriptionList/types";
-import { Paper } from "@/lib/ui/Paper";
 import { getProp } from "@/lib/utils/objects/higherOrderFuncs";
 import { LocalDatasetClient } from "@/models/LocalDataset/LocalDatasetClient";
 import { type LocalDataset } from "@/models/LocalDataset/types";
@@ -69,6 +71,8 @@ export function DatasetMetaView({ dataset }: Props): JSX.Element {
       id: dataset.id,
     });
 
+  const [isEditingDataset, setIsEditingDataset] = useState<boolean>(false);
+
   // TODO(jpsyx): eventually the dataset should be streamed, rather than
   // storing it all in memory. Right now this doesnt save any memory if we
   // load it all and then just take a slice.
@@ -102,7 +106,40 @@ export function DatasetMetaView({ dataset }: Props): JSX.Element {
   return (
     <Container pt="lg">
       <Stack>
-        <Title order={2}>{dataset.name}</Title>
+        <Group justify="space-between" align="center">
+          <Group gap="xs" align="center">
+            {
+              isEditingDataset ?
+                <Group>
+                  <EditDatasetView dataset={dataset} />
+                  <ActionIcon
+                    variant="subtle"
+                    aria-label="Exit edit"
+                    onClick={() => {
+                      return setIsEditingDataset(false);
+                    }}
+                  >
+                    <IconX size={20} />
+                  </ActionIcon>
+                </Group>
+                // optional “exit edit” action
+              : <Group>
+                  <Title order={2}>{dataset.name}</Title>
+                  <ActionIcon
+                    variant="subtle"
+                    aria-label="Edit dataset"
+                    onClick={() => {
+                      return setIsEditingDataset(true);
+                    }}
+                  >
+                    <IconPencil size={20} />
+                  </ActionIcon>
+                </Group>
+
+            }
+          </Group>
+        </Group>
+
         <Paper>
           <Tabs
             variant="none"
@@ -128,12 +165,6 @@ export function DatasetMetaView({ dataset }: Props): JSX.Element {
                 ref={tabItemRefCallback("dataset-summary")}
               >
                 <Text span>Data Summary</Text>
-              </Tabs.Tab>
-              <Tabs.Tab
-                value="dataset-edit"
-                ref={tabItemRefCallback("dataset-edit")}
-              >
-                <IconPencil size={20} />
               </Tabs.Tab>
 
               <FloatingIndicator
@@ -167,12 +198,6 @@ export function DatasetMetaView({ dataset }: Props): JSX.Element {
               {isLoadingParsedDataset || !parsedDataset ?
                 <Loader />
               : <DataSummaryView parsedDataset={parsedDataset} />}
-            </Tabs.Panel>
-
-            <Tabs.Panel value="dataset-edit">
-              {isLoadingParsedDataset ?
-                <Loader />
-              : <EditDatasetView dataset={dataset} />}
             </Tabs.Panel>
 
             <Button

--- a/src/components/DataManagerApp/DatasetMetaView/index.tsx
+++ b/src/components/DataManagerApp/DatasetMetaView/index.tsx
@@ -11,6 +11,7 @@ import {
 } from "@mantine/core";
 import { modals } from "@mantine/modals";
 import { notifications } from "@mantine/notifications";
+import { IconPencil } from "@tabler/icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
 import { AppLinks } from "@/config/AppLinks";
@@ -132,7 +133,7 @@ export function DatasetMetaView({ dataset }: Props): JSX.Element {
                 value="dataset-edit"
                 ref={tabItemRefCallback("dataset-edit")}
               >
-                <Text span>Edit Dataset</Text>
+                <IconPencil size={20} />
               </Tabs.Tab>
 
               <FloatingIndicator


### PR DESCRIPTION
Replaced 'Edit Dataset' text with a Mantine pencil icon. 

Ticket: https://github.com/AvandarLabs/avandar/issues/64

<img width="1097" height="1153" alt="Screenshot 2025-08-08 at 2 09 30 PM" src="https://github.com/user-attachments/assets/9189c1b9-beab-4b35-b778-8d17484977d7" />
