### PR TITLE
Chore/join confiugre callout only shows if multiple fields

### DIFF
--- a/src/lib/ui/ObjectDescriptionList/types.ts
+++ b/src/lib/ui/ObjectDescriptionList/types.ts
@@ -1,11 +1,6 @@
 import { ReactNode } from "react";
-<<<<<<< HEAD
 import { Registry, StringKeyOf } from "@/lib/types/utilityTypes";
 import { objectKeys } from "@/lib/utils/objects/misc";
-=======
-import { Registry, StringKeyOf } from "@/lib/types/utilityTypes";
-import { objectKeys } from "@/lib/utils/objects/misc";
->>>>>>> develop
 
 /** A non-recursive value */
 export type PrimitiveValue =


### PR DESCRIPTION
This adds a check for more than one datasets to show callout.

Ticket: https://github.com/AvandarLabs/avandar/issues/53

<img width="1020" height="992" alt="Screenshot 2025-08-11 at 5 14 57 PM" src="https://github.com/user-attachments/assets/74fdb480-38ae-4468-9df4-82f23341544d" />
<img width="1196" height="929" alt="Screenshot 2025-08-11 at 5 15 42 PM" src="https://github.com/user-attachments/assets/176537d3-4eeb-477d-a812-12076db0d856" />
