### PR TITLE
refactor the DataExplorerProvider and fixed callback in multiDataselect

### DIFF
--- a/src/components/common/DatasetSelect.tsx
+++ b/src/components/common/DatasetSelect.tsx
@@ -38,9 +38,12 @@ export function DatasetSelect({
     datasets,
     useCallback(
       (dsets) => {
-        onChangeValue(dsets[0]?.id ?? null);
+        // only default to the first dataset if nothing is currently selected
+        if (!controlledValue) {
+          onChangeValue(dsets[0]?.id ?? null);
+        }
       },
-      [onChangeValue],
+      [controlledValue, onChangeValue],
     ),
   );
 


### PR DESCRIPTION
Ok so I thought this was working before but perhaps I only tested the first dataset in the list. The first dataset in the dropdown DID persist but the others did not because DatasetSelect always reset the value to the first dataset’s ID when datasets loaded, so only that one appeared to persist while all others were overwritten.

I spent a lot of time refactoring the DataExplorerProvider hoping to fix it. I created an updateFormState helper so partial updates (e.g. new columns) don’t blow away the rest of the dataset’s state. This refactor is fine but ultimately the issue was deep down in a useCallback in `DatasetColumnMultiSelect.tsx`

Ticket: https://github.com/AvandarLabs/avandar/issues/65

https://www.loom.com/share/f5ca7df8b4f64308a9bf3644b1c97355?sid=34110b57-03e3-4c99-9d2f-7431a9918981