### PR TITLE
add ref to override focus on file input field

### DIFF
--- a/src/lib/ui/singleton-forms/FileUploadField.tsx
+++ b/src/lib/ui/singleton-forms/FileUploadField.tsx
@@ -1,5 +1,6 @@
 import { Button, FileInput, FileInputProps, Group } from "@mantine/core";
 import { useForm } from "@mantine/form";
+import { useRef } from "react";
 import { MIMEType } from "@/lib/types/common";
 
 type Props = {
@@ -62,6 +63,9 @@ export function FileUploadField({
     },
   });
 
+  // allow user to press enter to upload form
+  const submitRef = useRef<HTMLButtonElement>(null);
+
   return (
     <form
       onSubmit={form.onSubmit((values) => {
@@ -74,10 +78,17 @@ export function FileUploadField({
         {...form.getInputProps("file")}
         clearable={clearable}
         accept={accept}
+        onChange={(file) => {
+          form.setFieldValue("file", file);
+          setTimeout(() => {
+            submitRef.current?.focus();
+          }, 0);
+        }}
         {...fileInputProps}
       />
       <Group justify="flex-end" mt="md">
         <Button
+          ref={submitRef}
           type="submit"
           loading={isSubmitting}
           disabled={form.getValues().file === null}


### PR DESCRIPTION
Added simple ref to override the focus on input field.

Ticket: https://github.com/AvandarLabs/avandar/issues/132

https://www.loom.com/share/aa352adbcd874129a3898966ee7bfc92?sid=8827e71b-68f0-48d6-aede-2948a0f7af03