### PR TITLE
PTRCK-007, PTRCK-008, PTRCK-009, PTRCK-010: Data Explorer charts, URL session sync, viz defaults, and column remap

### DIFF
--- a/shared/models/vizs/AreaChartVizConfig/AreaChartVizConfig.types.ts
+++ b/shared/models/vizs/AreaChartVizConfig/AreaChartVizConfig.types.ts
@@ -1,22 +1,23 @@
-export type BarChartVizConfig = {
-  vizType: "bar";
+import type { CurveType } from "$/models/vizs/CurveType.ts";
+
+export type AreaChartVizConfig = {
+  vizType: "area";
 
   /**
    * The key of the column to use for the X axis. This is a column name,
    * not an ID.
-   *
-   * TODO(jpsyx): create a concept of a QueryColumn and use QueryColumnId here.
    */
   xAxisKey: string | undefined;
 
   /**
    * The key of the column to use for the Y axis. This is a column name,
    * not an ID.
-   *
-   * TODO(jpsyx): create a concept of a QueryColumn and use QueryColumnId here.
    */
   yAxisKey: string | undefined;
 
   /** Show the chart legend when `true`. */
   withLegend: boolean;
+
+  /** Curve interpolation style. Defaults to `"monotone"`. */
+  curveType: CurveType;
 };

--- a/shared/models/vizs/AreaChartVizConfig/AreaChartVizConfig.types.ts
+++ b/shared/models/vizs/AreaChartVizConfig/AreaChartVizConfig.types.ts
@@ -20,4 +20,7 @@ export type AreaChartVizConfig = {
 
   /** Curve interpolation style. Defaults to `"monotone"`. */
   curveType: CurveType;
+
+  /** Optional CSS color override for the data series (e.g. `"#ff0000"`). */
+  color?: string;
 };

--- a/shared/models/vizs/AreaChartVizConfig/AreaChartVizConfigs.ts
+++ b/shared/models/vizs/AreaChartVizConfig/AreaChartVizConfigs.ts
@@ -1,4 +1,8 @@
 import { match } from "ts-pattern";
+import { hydrateXYFromQuery } from "$/models/vizs/hydrateXYFromQuery.ts";
+import {
+  hydrateXYFromQueryResult,
+} from "$/models/vizs/hydrateXYFromQueryResult.ts";
 import type {
   AreaChartVizConfig,
 } from "$/models/vizs/AreaChartVizConfig/AreaChartVizConfig.types.ts";
@@ -24,6 +28,9 @@ import type {
   ScatterPlotVizConfig,
 } from "$/models/vizs/ScatterPlotVizConfig/ScatterPlotVizConfig.types.ts";
 import type {
+  TableVizConfig,
+} from "$/models/vizs/TableVizConfig/TableVizConfig.types.ts";
+import type {
   IVizConfigModule,
 } from "$/models/vizs/VizConfig/IVizConfigModule.ts";
 import type {
@@ -31,93 +38,93 @@ import type {
   VizType,
 } from "$/models/vizs/VizConfig/VizConfig.types.ts";
 import type {
-  TableVizConfig,
-} from "$/models/vizs/TableVizConfig/TableVizConfig.types.ts";
+  PartialStructuredQuery,
+} from "$/models/queries/StructuredQuery/StructuredQuery.types.ts";
 import type {
   QueryResultColumn,
 } from "$/models/queries/QueryResult/QueryResult.types.ts";
 
-export const TableVizConfigs = {
-  vizType: "table",
-  displayName: "Table",
+export const AreaChartVizConfigs = {
+  vizType: "area",
+  displayName: "Area Chart",
 
-  /** Create an empty table config */
-  makeEmptyConfig: (): TableVizConfig => {
-    return { vizType: "table" };
+  /** Create an empty area chart config. */
+  makeEmptyConfig: (): AreaChartVizConfig => {
+    return {
+      vizType: "area",
+      xAxisKey: undefined,
+      yAxisKey: undefined,
+      withLegend: true,
+      curveType: "monotone",
+    };
   },
 
   /**
-   * Hydrate a table viz config from a query config.
+   * Hydrate an area chart viz config from a query config.
    */
-  hydrateFromQuery: (vizConfig: TableVizConfig): TableVizConfig => {
-    return vizConfig;
+  hydrateFromQuery: (
+    vizConfig: AreaChartVizConfig,
+    query: PartialStructuredQuery,
+  ): AreaChartVizConfig => {
+    return hydrateXYFromQuery(vizConfig, query);
   },
 
   /**
-   * Table viz has no axis keys to hydrate from query results.
+   * Hydrate axis keys from query result columns when they are undefined.
    */
   hydrateFromQueryResult: (
-    vizConfig: TableVizConfig,
-    _columns: readonly QueryResultColumn[],
-  ): TableVizConfig => {
-    return vizConfig;
+    vizConfig: AreaChartVizConfig,
+    columns: readonly QueryResultColumn[],
+  ): AreaChartVizConfig => {
+    return hydrateXYFromQueryResult(vizConfig, columns, "line");
   },
 
   /**
-   * Convert a table config to a new type.
+   * Convert an area chart config to a new viz type.
    */
   convertVizConfig: <K extends VizType = VizType>(
-    vizConfig: TableVizConfig,
+    vizConfig: AreaChartVizConfig,
     newVizType: K,
   ): VizConfigType<K> => {
-    const emptyXY = { xAxisKey: undefined, yAxisKey: undefined };
-    const emptyPie = { nameKey: undefined, valueKey: undefined };
+    const { xAxisKey, yAxisKey, withLegend, curveType } = vizConfig;
+    const xyAxes = { xAxisKey, yAxisKey };
+    const pieAxes = { nameKey: xAxisKey, valueKey: yAxisKey };
     return match<VizType>(newVizType)
-      .with("table", (): TableVizConfig => {
-        return vizConfig;
+      .with("table", (vizType): TableVizConfig => {
+        return { vizType };
       })
       .with("bar", (vizType): BarChartVizConfig => {
-        return { vizType, ...emptyXY, withLegend: true };
+        return { vizType, ...xyAxes, withLegend };
       })
       .with("line", (vizType): LineChartVizConfig => {
-        return {
-          vizType,
-          ...emptyXY,
-          withLegend: true,
-          curveType: "monotone",
-        };
+        return { vizType, ...xyAxes, withLegend, curveType };
       })
-      .with("area", (vizType): AreaChartVizConfig => {
-        return {
-          vizType,
-          ...emptyXY,
-          withLegend: true,
-          curveType: "monotone",
-        };
+      .with("area", (): AreaChartVizConfig => {
+        return vizConfig;
       })
       .with("scatter", (vizType): ScatterPlotVizConfig => {
-        return { vizType, ...emptyXY };
+        return { vizType, ...xyAxes };
       })
       .with("pie", (vizType): PieChartVizConfig => {
         return {
           vizType,
-          ...emptyPie,
+          ...pieAxes,
           isDonut: false,
           withLabels: true,
           labelsType: "value",
         };
       })
       .with("funnel", (vizType): FunnelChartVizConfig => {
-        return { vizType, ...emptyPie };
+        return { vizType, ...pieAxes };
       })
       .with("radar", (vizType): RadarChartVizConfig => {
-        return { vizType, ...emptyPie };
+        return { vizType, ...pieAxes };
       })
       .with("bubble", (vizType): BubbleChartVizConfig => {
-        return { vizType, ...emptyXY, sizeKey: undefined };
+        return { vizType, ...xyAxes, sizeKey: undefined };
       })
       .exhaustive(() => {
         throw new Error(`Invalid viz type: ${newVizType}`);
       }) as VizConfigType<K>;
   },
-} as const satisfies IVizConfigModule<"table">;
+} as const satisfies IVizConfigModule<"area">;

--- a/shared/models/vizs/BarChartVizConfig/BarChartVizConfig.types.ts
+++ b/shared/models/vizs/BarChartVizConfig/BarChartVizConfig.types.ts
@@ -19,4 +19,7 @@ export type BarChartVizConfig = {
 
   /** Show the chart legend when `true`. */
   withLegend: boolean;
+
+  /** Optional CSS color override for the data series (e.g. `"#ff0000"`). */
+  color?: string;
 };

--- a/shared/models/vizs/BubbleChartVizConfig/BubbleChartVizConfig.types.ts
+++ b/shared/models/vizs/BubbleChartVizConfig/BubbleChartVizConfig.types.ts
@@ -1,0 +1,19 @@
+export type BubbleChartVizConfig = {
+  vizType: "bubble";
+
+  /**
+   * The numeric column for the X axis. This is a column name, not an ID.
+   */
+  xAxisKey: string | undefined;
+
+  /**
+   * The numeric column for the Y axis. This is a column name, not an ID.
+   */
+  yAxisKey: string | undefined;
+
+  /**
+   * The numeric column that controls bubble size. This is a column name,
+   * not an ID.
+   */
+  sizeKey: string | undefined;
+};

--- a/shared/models/vizs/BubbleChartVizConfig/BubbleChartVizConfigs.ts
+++ b/shared/models/vizs/BubbleChartVizConfig/BubbleChartVizConfigs.ts
@@ -1,6 +1,5 @@
 import { match } from "ts-pattern";
 import { hydrateXYFromQuery } from "$/models/vizs/hydrateXYFromQuery.ts";
-import { hydrateXYFromQueryResult } from "$/models/vizs/hydrateXYFromQueryResult.ts";
 import type {
   AreaChartVizConfig,
 } from "$/models/vizs/AreaChartVizConfig/AreaChartVizConfig.types.ts";
@@ -41,63 +40,78 @@ import type {
 import type {
   QueryResultColumn,
 } from "$/models/queries/QueryResult/QueryResult.types.ts";
+import { AvaDataTypes } from "$/models/datasets/AvaDataType/AvaDataTypes.ts";
 
-export const BarChartVizConfigs = {
-  vizType: "bar",
-  displayName: "Bar Chart",
+export const BubbleChartVizConfigs = {
+  vizType: "bubble",
+  displayName: "Bubble Chart",
 
-  /** Create an empty bar config */
-  makeEmptyConfig: (): BarChartVizConfig => {
+  /** Create an empty bubble chart config. */
+  makeEmptyConfig: (): BubbleChartVizConfig => {
     return {
-      vizType: "bar",
+      vizType: "bubble",
       xAxisKey: undefined,
       yAxisKey: undefined,
-      withLegend: true,
+      sizeKey: undefined,
     };
   },
 
   /**
-   * Hydrate a bar chart viz config from a query config.
+   * Hydrate a bubble chart viz config from a query config. Delegates X/Y
+   * hydration to the scatter heuristic; `sizeKey` is inferred from result
+   * columns only.
    */
   hydrateFromQuery: (
-    vizConfig: BarChartVizConfig,
+    vizConfig: BubbleChartVizConfig,
     query: PartialStructuredQuery,
-  ): BarChartVizConfig => {
+  ): BubbleChartVizConfig => {
     return hydrateXYFromQuery(vizConfig, query);
   },
 
   /**
-   * Hydrate axis keys from query result columns when they are undefined.
+   * Hydrate `xAxisKey`, `yAxisKey`, and `sizeKey` from query result columns.
+   * X and Y use the scatter numeric heuristic; `sizeKey` is the third
+   * available numeric column that is not X or Y.
    */
   hydrateFromQueryResult: (
-    vizConfig: BarChartVizConfig,
+    vizConfig: BubbleChartVizConfig,
     columns: readonly QueryResultColumn[],
-  ): BarChartVizConfig => {
-    return hydrateXYFromQueryResult(vizConfig, columns, "bar");
+  ): BubbleChartVizConfig => {
+    return _hydrateBubbleFromQueryResult(vizConfig, columns);
   },
 
   /**
-   * Convert a bar chart config to a new type.
+   * Convert a bubble chart config to a new viz type.
    */
   convertVizConfig: <K extends VizType = VizType>(
-    vizConfig: BarChartVizConfig,
+    vizConfig: BubbleChartVizConfig,
     newVizType: K,
   ): VizConfigType<K> => {
-    const { xAxisKey, yAxisKey, withLegend } = vizConfig;
+    const { xAxisKey, yAxisKey } = vizConfig;
     const xyAxes = { xAxisKey, yAxisKey };
     const pieAxes = { nameKey: xAxisKey, valueKey: yAxisKey };
     return match<VizType>(newVizType)
       .with("table", (vizType): TableVizConfig => {
         return { vizType };
       })
-      .with("bar", (): BarChartVizConfig => {
-        return vizConfig;
+      .with("bar", (vizType): BarChartVizConfig => {
+        return { vizType, ...xyAxes, withLegend: true };
       })
       .with("line", (vizType): LineChartVizConfig => {
-        return { vizType, ...xyAxes, withLegend, curveType: "monotone" };
+        return {
+          vizType,
+          ...xyAxes,
+          withLegend: true,
+          curveType: "monotone",
+        };
       })
       .with("area", (vizType): AreaChartVizConfig => {
-        return { vizType, ...xyAxes, withLegend, curveType: "monotone" };
+        return {
+          vizType,
+          ...xyAxes,
+          withLegend: true,
+          curveType: "monotone",
+        };
       })
       .with("scatter", (vizType): ScatterPlotVizConfig => {
         return { vizType, ...xyAxes };
@@ -117,11 +131,53 @@ export const BarChartVizConfigs = {
       .with("radar", (vizType): RadarChartVizConfig => {
         return { vizType, ...pieAxes };
       })
-      .with("bubble", (vizType): BubbleChartVizConfig => {
-        return { vizType, ...xyAxes, sizeKey: undefined };
+      .with("bubble", (): BubbleChartVizConfig => {
+        return vizConfig;
       })
       .exhaustive(() => {
         throw new Error(`Invalid viz type: ${newVizType}`);
       }) as VizConfigType<K>;
   },
-} as const satisfies IVizConfigModule<"bar">;
+} as const satisfies IVizConfigModule<"bubble">;
+
+function _hydrateBubbleFromQueryResult(
+  vizConfig: BubbleChartVizConfig,
+  columns: readonly QueryResultColumn[],
+): BubbleChartVizConfig {
+  if (columns.length === 0) {
+    return vizConfig;
+  }
+
+  const numericCols = columns.filter((c) => {
+    return AvaDataTypes.isNumeric(c.dataType);
+  });
+
+  let next = { ...vizConfig };
+
+  if (next.xAxisKey === undefined) {
+    const xCol = numericCols[0];
+    if (xCol !== undefined) {
+      next = { ...next, xAxisKey: xCol.name };
+    }
+  }
+
+  if (next.yAxisKey === undefined) {
+    const yCol = numericCols.find((c) => {
+      return c.name !== next.xAxisKey;
+    });
+    if (yCol !== undefined) {
+      next = { ...next, yAxisKey: yCol.name };
+    }
+  }
+
+  if (next.sizeKey === undefined) {
+    const sizeCol = numericCols.find((c) => {
+      return c.name !== next.xAxisKey && c.name !== next.yAxisKey;
+    });
+    if (sizeCol !== undefined) {
+      next = { ...next, sizeKey: sizeCol.name };
+    }
+  }
+
+  return next;
+}

--- a/shared/models/vizs/CurveType.ts
+++ b/shared/models/vizs/CurveType.ts
@@ -1,0 +1,5 @@
+/**
+ * Curve interpolation options for line and area charts.
+ * Maps to Mantine Charts' `LineChartCurveType` / `AreaChartCurveType`.
+ */
+export type CurveType = "linear" | "natural" | "monotone" | "step";

--- a/shared/models/vizs/FunnelChartVizConfig/FunnelChartVizConfig.types.ts
+++ b/shared/models/vizs/FunnelChartVizConfig/FunnelChartVizConfig.types.ts
@@ -12,4 +12,10 @@ export type FunnelChartVizConfig = {
    * This is a column name, not an ID.
    */
   valueKey: string | undefined;
+
+  /**
+   * Optional per-step color overrides, keyed by the step's name value.
+   * Values are CSS color strings (e.g. `"#ff0000"` or `"blue.6"`).
+   */
+  seriesColors?: Record<string, string>;
 };

--- a/shared/models/vizs/FunnelChartVizConfig/FunnelChartVizConfig.types.ts
+++ b/shared/models/vizs/FunnelChartVizConfig/FunnelChartVizConfig.types.ts
@@ -1,0 +1,15 @@
+export type FunnelChartVizConfig = {
+  vizType: "funnel";
+
+  /**
+   * The column whose values label each funnel step (name / category).
+   * This is a column name, not an ID.
+   */
+  nameKey: string | undefined;
+
+  /**
+   * The numeric column whose values determine step width.
+   * This is a column name, not an ID.
+   */
+  valueKey: string | undefined;
+};

--- a/shared/models/vizs/FunnelChartVizConfig/FunnelChartVizConfigs.ts
+++ b/shared/models/vizs/FunnelChartVizConfig/FunnelChartVizConfigs.ts
@@ -1,4 +1,8 @@
 import { match } from "ts-pattern";
+import { hydratePieFromQuery } from "$/models/vizs/hydratePieFromQuery.ts";
+import {
+  hydratePieFromQueryResult,
+} from "$/models/vizs/hydratePieFromQueryResult.ts";
 import type {
   AreaChartVizConfig,
 } from "$/models/vizs/AreaChartVizConfig/AreaChartVizConfig.types.ts";
@@ -24,6 +28,9 @@ import type {
   ScatterPlotVizConfig,
 } from "$/models/vizs/ScatterPlotVizConfig/ScatterPlotVizConfig.types.ts";
 import type {
+  TableVizConfig,
+} from "$/models/vizs/TableVizConfig/TableVizConfig.types.ts";
+import type {
   IVizConfigModule,
 } from "$/models/vizs/VizConfig/IVizConfigModule.ts";
 import type {
@@ -31,58 +38,62 @@ import type {
   VizType,
 } from "$/models/vizs/VizConfig/VizConfig.types.ts";
 import type {
-  TableVizConfig,
-} from "$/models/vizs/TableVizConfig/TableVizConfig.types.ts";
+  PartialStructuredQuery,
+} from "$/models/queries/StructuredQuery/StructuredQuery.types.ts";
 import type {
   QueryResultColumn,
 } from "$/models/queries/QueryResult/QueryResult.types.ts";
 
-export const TableVizConfigs = {
-  vizType: "table",
-  displayName: "Table",
+export const FunnelChartVizConfigs = {
+  vizType: "funnel",
+  displayName: "Funnel Chart",
 
-  /** Create an empty table config */
-  makeEmptyConfig: (): TableVizConfig => {
-    return { vizType: "table" };
+  /** Create an empty funnel chart config. */
+  makeEmptyConfig: (): FunnelChartVizConfig => {
+    return { vizType: "funnel", nameKey: undefined, valueKey: undefined };
   },
 
   /**
-   * Hydrate a table viz config from a query config.
+   * Hydrate a funnel chart viz config from a query config.
    */
-  hydrateFromQuery: (vizConfig: TableVizConfig): TableVizConfig => {
-    return vizConfig;
+  hydrateFromQuery: (
+    vizConfig: FunnelChartVizConfig,
+    query: PartialStructuredQuery,
+  ): FunnelChartVizConfig => {
+    return hydratePieFromQuery(vizConfig, query);
   },
 
   /**
-   * Table viz has no axis keys to hydrate from query results.
+   * Hydrate `nameKey` and `valueKey` from query result column metadata.
    */
   hydrateFromQueryResult: (
-    vizConfig: TableVizConfig,
-    _columns: readonly QueryResultColumn[],
-  ): TableVizConfig => {
-    return vizConfig;
+    vizConfig: FunnelChartVizConfig,
+    columns: readonly QueryResultColumn[],
+  ): FunnelChartVizConfig => {
+    return hydratePieFromQueryResult(vizConfig, columns);
   },
 
   /**
-   * Convert a table config to a new type.
+   * Convert a funnel chart config to a new viz type.
    */
   convertVizConfig: <K extends VizType = VizType>(
-    vizConfig: TableVizConfig,
+    vizConfig: FunnelChartVizConfig,
     newVizType: K,
   ): VizConfigType<K> => {
-    const emptyXY = { xAxisKey: undefined, yAxisKey: undefined };
-    const emptyPie = { nameKey: undefined, valueKey: undefined };
+    const { nameKey, valueKey } = vizConfig;
+    const xyAxes = { xAxisKey: nameKey, yAxisKey: valueKey };
+    const pieAxes = { nameKey, valueKey };
     return match<VizType>(newVizType)
-      .with("table", (): TableVizConfig => {
-        return vizConfig;
+      .with("table", (vizType): TableVizConfig => {
+        return { vizType };
       })
       .with("bar", (vizType): BarChartVizConfig => {
-        return { vizType, ...emptyXY, withLegend: true };
+        return { vizType, ...xyAxes, withLegend: true };
       })
       .with("line", (vizType): LineChartVizConfig => {
         return {
           vizType,
-          ...emptyXY,
+          ...xyAxes,
           withLegend: true,
           curveType: "monotone",
         };
@@ -90,34 +101,34 @@ export const TableVizConfigs = {
       .with("area", (vizType): AreaChartVizConfig => {
         return {
           vizType,
-          ...emptyXY,
+          ...xyAxes,
           withLegend: true,
           curveType: "monotone",
         };
       })
       .with("scatter", (vizType): ScatterPlotVizConfig => {
-        return { vizType, ...emptyXY };
+        return { vizType, ...xyAxes };
       })
       .with("pie", (vizType): PieChartVizConfig => {
         return {
           vizType,
-          ...emptyPie,
+          ...pieAxes,
           isDonut: false,
           withLabels: true,
           labelsType: "value",
         };
       })
-      .with("funnel", (vizType): FunnelChartVizConfig => {
-        return { vizType, ...emptyPie };
+      .with("funnel", (): FunnelChartVizConfig => {
+        return vizConfig;
       })
       .with("radar", (vizType): RadarChartVizConfig => {
-        return { vizType, ...emptyPie };
+        return { vizType, ...pieAxes };
       })
       .with("bubble", (vizType): BubbleChartVizConfig => {
-        return { vizType, ...emptyXY, sizeKey: undefined };
+        return { vizType, ...xyAxes, sizeKey: undefined };
       })
       .exhaustive(() => {
         throw new Error(`Invalid viz type: ${newVizType}`);
       }) as VizConfigType<K>;
   },
-} as const satisfies IVizConfigModule<"table">;
+} as const satisfies IVizConfigModule<"funnel">;

--- a/shared/models/vizs/LineChartVizConfig/LineChartVizConfig.types.ts
+++ b/shared/models/vizs/LineChartVizConfig/LineChartVizConfig.types.ts
@@ -24,4 +24,7 @@ export type LineChartVizConfig = {
 
   /** Curve interpolation style. Defaults to `"monotone"`. */
   curveType: CurveType;
+
+  /** Optional CSS color override for the data series (e.g. `"#ff0000"`). */
+  color?: string;
 };

--- a/shared/models/vizs/LineChartVizConfig/LineChartVizConfig.types.ts
+++ b/shared/models/vizs/LineChartVizConfig/LineChartVizConfig.types.ts
@@ -1,3 +1,5 @@
+import type { CurveType } from "$/models/vizs/CurveType.ts";
+
 export type LineChartVizConfig = {
   vizType: "line";
 
@@ -16,4 +18,10 @@ export type LineChartVizConfig = {
    * TODO(jpsyx): create a concept of a QueryColumn and use QueryColumnId here.
    */
   yAxisKey: string | undefined;
+
+  /** Show the chart legend when `true`. */
+  withLegend: boolean;
+
+  /** Curve interpolation style. Defaults to `"monotone"`. */
+  curveType: CurveType;
 };

--- a/shared/models/vizs/LineChartVizConfig/LineChartVizConfigs.ts
+++ b/shared/models/vizs/LineChartVizConfig/LineChartVizConfigs.ts
@@ -1,15 +1,46 @@
-import { pick } from "@utils/objects/pick/pick.ts";
 import { match } from "ts-pattern";
 import { hydrateXYFromQuery } from "$/models/vizs/hydrateXYFromQuery.ts";
 import { hydrateXYFromQueryResult } from "$/models/vizs/hydrateXYFromQueryResult.ts";
-import type { BarChartVizConfig } from "$/models/vizs/BarChartVizConfig/BarChartVizConfig.types.ts";
-import type { ScatterPlotVizConfig } from "$/models/vizs/ScatterPlotVizConfig/ScatterPlotVizConfig.types.ts";
-import type { TableVizConfig } from "$/models/vizs/TableVizConfig/TableVizConfig.types.ts";
-import type { IVizConfigModule } from "$/models/vizs/VizConfig/IVizConfigModule.ts";
-import type { VizConfigType, VizType } from "$/models/vizs/VizConfig/VizConfig.types.ts";
-import type { LineChartVizConfig } from "$/models/vizs/LineChartVizConfig/LineChartVizConfig.types.ts";
-import type { PartialStructuredQuery } from "$/models/queries/StructuredQuery/StructuredQuery.types.ts";
-import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types.ts";
+import type {
+  AreaChartVizConfig,
+} from "$/models/vizs/AreaChartVizConfig/AreaChartVizConfig.types.ts";
+import type {
+  BarChartVizConfig,
+} from "$/models/vizs/BarChartVizConfig/BarChartVizConfig.types.ts";
+import type {
+  BubbleChartVizConfig,
+} from "$/models/vizs/BubbleChartVizConfig/BubbleChartVizConfig.types.ts";
+import type {
+  FunnelChartVizConfig,
+} from "$/models/vizs/FunnelChartVizConfig/FunnelChartVizConfig.types.ts";
+import type {
+  LineChartVizConfig,
+} from "$/models/vizs/LineChartVizConfig/LineChartVizConfig.types.ts";
+import type {
+  PieChartVizConfig,
+} from "$/models/vizs/PieChartVizConfig/PieChartVizConfig.types.ts";
+import type {
+  RadarChartVizConfig,
+} from "$/models/vizs/RadarChartVizConfig/RadarChartVizConfig.types.ts";
+import type {
+  ScatterPlotVizConfig,
+} from "$/models/vizs/ScatterPlotVizConfig/ScatterPlotVizConfig.types.ts";
+import type {
+  TableVizConfig,
+} from "$/models/vizs/TableVizConfig/TableVizConfig.types.ts";
+import type {
+  IVizConfigModule,
+} from "$/models/vizs/VizConfig/IVizConfigModule.ts";
+import type {
+  VizConfigType,
+  VizType,
+} from "$/models/vizs/VizConfig/VizConfig.types.ts";
+import type {
+  PartialStructuredQuery,
+} from "$/models/queries/StructuredQuery/StructuredQuery.types.ts";
+import type {
+  QueryResultColumn,
+} from "$/models/queries/QueryResult/QueryResult.types.ts";
 
 export const LineChartVizConfigs = {
   vizType: "line",
@@ -17,7 +48,13 @@ export const LineChartVizConfigs = {
 
   /** Create an empty line chart config */
   makeEmptyConfig: (): LineChartVizConfig => {
-    return { vizType: "line", xAxisKey: undefined, yAxisKey: undefined };
+    return {
+      vizType: "line",
+      xAxisKey: undefined,
+      yAxisKey: undefined,
+      withLegend: true,
+      curveType: "monotone",
+    };
   },
 
   /**
@@ -47,19 +84,42 @@ export const LineChartVizConfigs = {
     vizConfig: LineChartVizConfig,
     newVizType: K,
   ): VizConfigType<K> => {
-    const currentAxes = pick(vizConfig, ["xAxisKey", "yAxisKey"]);
+    const { xAxisKey, yAxisKey, withLegend, curveType } = vizConfig;
+    const xyAxes = { xAxisKey, yAxisKey };
+    const pieAxes = { nameKey: xAxisKey, valueKey: yAxisKey };
     return match<VizType>(newVizType)
       .with("table", (vizType): TableVizConfig => {
         return { vizType };
       })
       .with("bar", (vizType): BarChartVizConfig => {
-        return { vizType, ...currentAxes };
+        return { vizType, ...xyAxes, withLegend };
       })
       .with("line", (): LineChartVizConfig => {
         return vizConfig;
       })
+      .with("area", (vizType): AreaChartVizConfig => {
+        return { vizType, ...xyAxes, withLegend, curveType };
+      })
       .with("scatter", (vizType): ScatterPlotVizConfig => {
-        return { vizType, ...currentAxes };
+        return { vizType, ...xyAxes };
+      })
+      .with("pie", (vizType): PieChartVizConfig => {
+        return {
+          vizType,
+          ...pieAxes,
+          isDonut: false,
+          withLabels: true,
+          labelsType: "value",
+        };
+      })
+      .with("funnel", (vizType): FunnelChartVizConfig => {
+        return { vizType, ...pieAxes };
+      })
+      .with("radar", (vizType): RadarChartVizConfig => {
+        return { vizType, ...pieAxes };
+      })
+      .with("bubble", (vizType): BubbleChartVizConfig => {
+        return { vizType, ...xyAxes, sizeKey: undefined };
       })
       .exhaustive(() => {
         throw new Error(`Invalid viz type: ${newVizType}`);

--- a/shared/models/vizs/PieChartVizConfig/PieChartVizConfig.types.ts
+++ b/shared/models/vizs/PieChartVizConfig/PieChartVizConfig.types.ts
@@ -24,4 +24,10 @@ export type PieChartVizConfig = {
 
   /** Controls what each label displays. Defaults to `"value"`. */
   labelsType: "value" | "percent";
+
+  /**
+   * Optional per-slice color overrides, keyed by the slice's name value.
+   * Values are CSS color strings (e.g. `"#ff0000"` or `"blue.6"`).
+   */
+  seriesColors?: Record<string, string>;
 };

--- a/shared/models/vizs/PieChartVizConfig/PieChartVizConfig.types.ts
+++ b/shared/models/vizs/PieChartVizConfig/PieChartVizConfig.types.ts
@@ -1,0 +1,27 @@
+export type PieChartVizConfig = {
+  vizType: "pie";
+
+  /**
+   * The column whose values label each slice (name / category).
+   * This is a column name, not an ID.
+   */
+  nameKey: string | undefined;
+
+  /**
+   * The numeric column whose values determine slice size.
+   * This is a column name, not an ID.
+   */
+  valueKey: string | undefined;
+
+  /** Render the chart as a donut instead of a filled pie. */
+  isDonut: boolean;
+
+  /**
+   * Render a label on each slice when `true`. Labels show either the
+   * raw value or a percentage based on `labelsType`.
+   */
+  withLabels: boolean;
+
+  /** Controls what each label displays. Defaults to `"value"`. */
+  labelsType: "value" | "percent";
+};

--- a/shared/models/vizs/PieChartVizConfig/PieChartVizConfigs.ts
+++ b/shared/models/vizs/PieChartVizConfig/PieChartVizConfigs.ts
@@ -1,4 +1,8 @@
 import { match } from "ts-pattern";
+import { hydratePieFromQuery } from "$/models/vizs/hydratePieFromQuery.ts";
+import {
+  hydratePieFromQueryResult,
+} from "$/models/vizs/hydratePieFromQueryResult.ts";
 import type {
   AreaChartVizConfig,
 } from "$/models/vizs/AreaChartVizConfig/AreaChartVizConfig.types.ts";
@@ -24,6 +28,9 @@ import type {
   ScatterPlotVizConfig,
 } from "$/models/vizs/ScatterPlotVizConfig/ScatterPlotVizConfig.types.ts";
 import type {
+  TableVizConfig,
+} from "$/models/vizs/TableVizConfig/TableVizConfig.types.ts";
+import type {
   IVizConfigModule,
 } from "$/models/vizs/VizConfig/IVizConfigModule.ts";
 import type {
@@ -31,58 +38,69 @@ import type {
   VizType,
 } from "$/models/vizs/VizConfig/VizConfig.types.ts";
 import type {
-  TableVizConfig,
-} from "$/models/vizs/TableVizConfig/TableVizConfig.types.ts";
+  PartialStructuredQuery,
+} from "$/models/queries/StructuredQuery/StructuredQuery.types.ts";
 import type {
   QueryResultColumn,
 } from "$/models/queries/QueryResult/QueryResult.types.ts";
 
-export const TableVizConfigs = {
-  vizType: "table",
-  displayName: "Table",
+export const PieChartVizConfigs = {
+  vizType: "pie",
+  displayName: "Pie Chart",
 
-  /** Create an empty table config */
-  makeEmptyConfig: (): TableVizConfig => {
-    return { vizType: "table" };
+  /** Create an empty pie chart config. */
+  makeEmptyConfig: (): PieChartVizConfig => {
+    return {
+      vizType: "pie",
+      nameKey: undefined,
+      valueKey: undefined,
+      isDonut: false,
+      withLabels: true,
+      labelsType: "value",
+    };
   },
 
   /**
-   * Hydrate a table viz config from a query config.
+   * Hydrate a pie chart viz config from a query config.
    */
-  hydrateFromQuery: (vizConfig: TableVizConfig): TableVizConfig => {
-    return vizConfig;
+  hydrateFromQuery: (
+    vizConfig: PieChartVizConfig,
+    query: PartialStructuredQuery,
+  ): PieChartVizConfig => {
+    return hydratePieFromQuery(vizConfig, query);
   },
 
   /**
-   * Table viz has no axis keys to hydrate from query results.
+   * Hydrate `nameKey` and `valueKey` from query result column metadata.
    */
   hydrateFromQueryResult: (
-    vizConfig: TableVizConfig,
-    _columns: readonly QueryResultColumn[],
-  ): TableVizConfig => {
-    return vizConfig;
+    vizConfig: PieChartVizConfig,
+    columns: readonly QueryResultColumn[],
+  ): PieChartVizConfig => {
+    return hydratePieFromQueryResult(vizConfig, columns);
   },
 
   /**
-   * Convert a table config to a new type.
+   * Convert a pie chart config to a new viz type.
    */
   convertVizConfig: <K extends VizType = VizType>(
-    vizConfig: TableVizConfig,
+    vizConfig: PieChartVizConfig,
     newVizType: K,
   ): VizConfigType<K> => {
-    const emptyXY = { xAxisKey: undefined, yAxisKey: undefined };
-    const emptyPie = { nameKey: undefined, valueKey: undefined };
+    const { nameKey, valueKey } = vizConfig;
+    const xyAxes = { xAxisKey: nameKey, yAxisKey: valueKey };
+    const pieAxes = { nameKey, valueKey };
     return match<VizType>(newVizType)
-      .with("table", (): TableVizConfig => {
-        return vizConfig;
+      .with("table", (vizType): TableVizConfig => {
+        return { vizType };
       })
       .with("bar", (vizType): BarChartVizConfig => {
-        return { vizType, ...emptyXY, withLegend: true };
+        return { vizType, ...xyAxes, withLegend: true };
       })
       .with("line", (vizType): LineChartVizConfig => {
         return {
           vizType,
-          ...emptyXY,
+          ...xyAxes,
           withLegend: true,
           curveType: "monotone",
         };
@@ -90,34 +108,28 @@ export const TableVizConfigs = {
       .with("area", (vizType): AreaChartVizConfig => {
         return {
           vizType,
-          ...emptyXY,
+          ...xyAxes,
           withLegend: true,
           curveType: "monotone",
         };
       })
       .with("scatter", (vizType): ScatterPlotVizConfig => {
-        return { vizType, ...emptyXY };
+        return { vizType, ...xyAxes };
       })
-      .with("pie", (vizType): PieChartVizConfig => {
-        return {
-          vizType,
-          ...emptyPie,
-          isDonut: false,
-          withLabels: true,
-          labelsType: "value",
-        };
+      .with("pie", (): PieChartVizConfig => {
+        return vizConfig;
       })
       .with("funnel", (vizType): FunnelChartVizConfig => {
-        return { vizType, ...emptyPie };
+        return { vizType, ...pieAxes };
       })
       .with("radar", (vizType): RadarChartVizConfig => {
-        return { vizType, ...emptyPie };
+        return { vizType, ...pieAxes };
       })
       .with("bubble", (vizType): BubbleChartVizConfig => {
-        return { vizType, ...emptyXY, sizeKey: undefined };
+        return { vizType, ...xyAxes, sizeKey: undefined };
       })
       .exhaustive(() => {
         throw new Error(`Invalid viz type: ${newVizType}`);
       }) as VizConfigType<K>;
   },
-} as const satisfies IVizConfigModule<"table">;
+} as const satisfies IVizConfigModule<"pie">;

--- a/shared/models/vizs/RadarChartVizConfig/RadarChartVizConfig.types.ts
+++ b/shared/models/vizs/RadarChartVizConfig/RadarChartVizConfig.types.ts
@@ -1,0 +1,15 @@
+export type RadarChartVizConfig = {
+  vizType: "radar";
+
+  /**
+   * The column whose values label each axis of the radar (category).
+   * This is a column name, not an ID.
+   */
+  nameKey: string | undefined;
+
+  /**
+   * The numeric column whose values determine the magnitude on each axis.
+   * This is a column name, not an ID.
+   */
+  valueKey: string | undefined;
+};

--- a/shared/models/vizs/RadarChartVizConfig/RadarChartVizConfig.types.ts
+++ b/shared/models/vizs/RadarChartVizConfig/RadarChartVizConfig.types.ts
@@ -12,4 +12,7 @@ export type RadarChartVizConfig = {
    * This is a column name, not an ID.
    */
   valueKey: string | undefined;
+
+  /** Optional CSS color override for the radar polygon (e.g. `"#ff0000"`). */
+  color?: string;
 };

--- a/shared/models/vizs/RadarChartVizConfig/RadarChartVizConfigs.ts
+++ b/shared/models/vizs/RadarChartVizConfig/RadarChartVizConfigs.ts
@@ -1,4 +1,8 @@
 import { match } from "ts-pattern";
+import { hydratePieFromQuery } from "$/models/vizs/hydratePieFromQuery.ts";
+import {
+  hydratePieFromQueryResult,
+} from "$/models/vizs/hydratePieFromQueryResult.ts";
 import type {
   AreaChartVizConfig,
 } from "$/models/vizs/AreaChartVizConfig/AreaChartVizConfig.types.ts";
@@ -24,6 +28,9 @@ import type {
   ScatterPlotVizConfig,
 } from "$/models/vizs/ScatterPlotVizConfig/ScatterPlotVizConfig.types.ts";
 import type {
+  TableVizConfig,
+} from "$/models/vizs/TableVizConfig/TableVizConfig.types.ts";
+import type {
   IVizConfigModule,
 } from "$/models/vizs/VizConfig/IVizConfigModule.ts";
 import type {
@@ -31,58 +38,62 @@ import type {
   VizType,
 } from "$/models/vizs/VizConfig/VizConfig.types.ts";
 import type {
-  TableVizConfig,
-} from "$/models/vizs/TableVizConfig/TableVizConfig.types.ts";
+  PartialStructuredQuery,
+} from "$/models/queries/StructuredQuery/StructuredQuery.types.ts";
 import type {
   QueryResultColumn,
 } from "$/models/queries/QueryResult/QueryResult.types.ts";
 
-export const TableVizConfigs = {
-  vizType: "table",
-  displayName: "Table",
+export const RadarChartVizConfigs = {
+  vizType: "radar",
+  displayName: "Radar Chart",
 
-  /** Create an empty table config */
-  makeEmptyConfig: (): TableVizConfig => {
-    return { vizType: "table" };
+  /** Create an empty radar chart config. */
+  makeEmptyConfig: (): RadarChartVizConfig => {
+    return { vizType: "radar", nameKey: undefined, valueKey: undefined };
   },
 
   /**
-   * Hydrate a table viz config from a query config.
+   * Hydrate a radar chart viz config from a query config.
    */
-  hydrateFromQuery: (vizConfig: TableVizConfig): TableVizConfig => {
-    return vizConfig;
+  hydrateFromQuery: (
+    vizConfig: RadarChartVizConfig,
+    query: PartialStructuredQuery,
+  ): RadarChartVizConfig => {
+    return hydratePieFromQuery(vizConfig, query);
   },
 
   /**
-   * Table viz has no axis keys to hydrate from query results.
+   * Hydrate `nameKey` and `valueKey` from query result column metadata.
    */
   hydrateFromQueryResult: (
-    vizConfig: TableVizConfig,
-    _columns: readonly QueryResultColumn[],
-  ): TableVizConfig => {
-    return vizConfig;
+    vizConfig: RadarChartVizConfig,
+    columns: readonly QueryResultColumn[],
+  ): RadarChartVizConfig => {
+    return hydratePieFromQueryResult(vizConfig, columns);
   },
 
   /**
-   * Convert a table config to a new type.
+   * Convert a radar chart config to a new viz type.
    */
   convertVizConfig: <K extends VizType = VizType>(
-    vizConfig: TableVizConfig,
+    vizConfig: RadarChartVizConfig,
     newVizType: K,
   ): VizConfigType<K> => {
-    const emptyXY = { xAxisKey: undefined, yAxisKey: undefined };
-    const emptyPie = { nameKey: undefined, valueKey: undefined };
+    const { nameKey, valueKey } = vizConfig;
+    const xyAxes = { xAxisKey: nameKey, yAxisKey: valueKey };
+    const pieAxes = { nameKey, valueKey };
     return match<VizType>(newVizType)
-      .with("table", (): TableVizConfig => {
-        return vizConfig;
+      .with("table", (vizType): TableVizConfig => {
+        return { vizType };
       })
       .with("bar", (vizType): BarChartVizConfig => {
-        return { vizType, ...emptyXY, withLegend: true };
+        return { vizType, ...xyAxes, withLegend: true };
       })
       .with("line", (vizType): LineChartVizConfig => {
         return {
           vizType,
-          ...emptyXY,
+          ...xyAxes,
           withLegend: true,
           curveType: "monotone",
         };
@@ -90,34 +101,34 @@ export const TableVizConfigs = {
       .with("area", (vizType): AreaChartVizConfig => {
         return {
           vizType,
-          ...emptyXY,
+          ...xyAxes,
           withLegend: true,
           curveType: "monotone",
         };
       })
       .with("scatter", (vizType): ScatterPlotVizConfig => {
-        return { vizType, ...emptyXY };
+        return { vizType, ...xyAxes };
       })
       .with("pie", (vizType): PieChartVizConfig => {
         return {
           vizType,
-          ...emptyPie,
+          ...pieAxes,
           isDonut: false,
           withLabels: true,
           labelsType: "value",
         };
       })
       .with("funnel", (vizType): FunnelChartVizConfig => {
-        return { vizType, ...emptyPie };
+        return { vizType, ...pieAxes };
       })
-      .with("radar", (vizType): RadarChartVizConfig => {
-        return { vizType, ...emptyPie };
+      .with("radar", (): RadarChartVizConfig => {
+        return vizConfig;
       })
       .with("bubble", (vizType): BubbleChartVizConfig => {
-        return { vizType, ...emptyXY, sizeKey: undefined };
+        return { vizType, ...xyAxes, sizeKey: undefined };
       })
       .exhaustive(() => {
         throw new Error(`Invalid viz type: ${newVizType}`);
       }) as VizConfigType<K>;
   },
-} as const satisfies IVizConfigModule<"table">;
+} as const satisfies IVizConfigModule<"radar">;

--- a/shared/models/vizs/ScatterPlotVizConfig/ScatterPlotVizConfigs.ts
+++ b/shared/models/vizs/ScatterPlotVizConfig/ScatterPlotVizConfigs.ts
@@ -1,15 +1,46 @@
-import { pick } from "@utils/objects/pick/pick.ts";
 import { match } from "ts-pattern";
 import { hydrateXYFromQuery } from "$/models/vizs/hydrateXYFromQuery.ts";
 import { hydrateXYFromQueryResult } from "$/models/vizs/hydrateXYFromQueryResult.ts";
-import type { BarChartVizConfig } from "$/models/vizs/BarChartVizConfig/BarChartVizConfig.types.ts";
-import type { LineChartVizConfig } from "$/models/vizs/LineChartVizConfig/LineChartVizConfig.types.ts";
-import type { TableVizConfig } from "$/models/vizs/TableVizConfig/TableVizConfig.types.ts";
-import type { IVizConfigModule } from "$/models/vizs/VizConfig/IVizConfigModule.ts";
-import type { VizConfigType, VizType } from "$/models/vizs/VizConfig/VizConfig.types.ts";
-import type { ScatterPlotVizConfig } from "$/models/vizs/ScatterPlotVizConfig/ScatterPlotVizConfig.types.ts";
-import type { PartialStructuredQuery } from "$/models/queries/StructuredQuery/StructuredQuery.types.ts";
-import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types.ts";
+import type {
+  AreaChartVizConfig,
+} from "$/models/vizs/AreaChartVizConfig/AreaChartVizConfig.types.ts";
+import type {
+  BarChartVizConfig,
+} from "$/models/vizs/BarChartVizConfig/BarChartVizConfig.types.ts";
+import type {
+  BubbleChartVizConfig,
+} from "$/models/vizs/BubbleChartVizConfig/BubbleChartVizConfig.types.ts";
+import type {
+  FunnelChartVizConfig,
+} from "$/models/vizs/FunnelChartVizConfig/FunnelChartVizConfig.types.ts";
+import type {
+  LineChartVizConfig,
+} from "$/models/vizs/LineChartVizConfig/LineChartVizConfig.types.ts";
+import type {
+  PieChartVizConfig,
+} from "$/models/vizs/PieChartVizConfig/PieChartVizConfig.types.ts";
+import type {
+  RadarChartVizConfig,
+} from "$/models/vizs/RadarChartVizConfig/RadarChartVizConfig.types.ts";
+import type {
+  TableVizConfig,
+} from "$/models/vizs/TableVizConfig/TableVizConfig.types.ts";
+import type {
+  IVizConfigModule,
+} from "$/models/vizs/VizConfig/IVizConfigModule.ts";
+import type {
+  VizConfigType,
+  VizType,
+} from "$/models/vizs/VizConfig/VizConfig.types.ts";
+import type {
+  ScatterPlotVizConfig,
+} from "$/models/vizs/ScatterPlotVizConfig/ScatterPlotVizConfig.types.ts";
+import type {
+  PartialStructuredQuery,
+} from "$/models/queries/StructuredQuery/StructuredQuery.types.ts";
+import type {
+  QueryResultColumn,
+} from "$/models/queries/QueryResult/QueryResult.types.ts";
 
 export const ScatterPlotVizConfigs = {
   vizType: "scatter",
@@ -47,19 +78,42 @@ export const ScatterPlotVizConfigs = {
     vizConfig: ScatterPlotVizConfig,
     newVizType: K,
   ): VizConfigType<K> => {
-    const currentAxes = pick(vizConfig, ["xAxisKey", "yAxisKey"]);
+    const { xAxisKey, yAxisKey } = vizConfig;
+    const xyAxes = { xAxisKey, yAxisKey };
+    const pieAxes = { nameKey: xAxisKey, valueKey: yAxisKey };
     return match<VizType>(newVizType)
       .with("table", (vizType): TableVizConfig => {
         return { vizType };
       })
       .with("bar", (vizType): BarChartVizConfig => {
-        return { vizType, ...currentAxes };
+        return { vizType, ...xyAxes, withLegend: true };
       })
       .with("line", (vizType): LineChartVizConfig => {
-        return { vizType, ...currentAxes };
+        return { vizType, ...xyAxes, withLegend: true, curveType: "monotone" };
+      })
+      .with("area", (vizType): AreaChartVizConfig => {
+        return { vizType, ...xyAxes, withLegend: true, curveType: "monotone" };
       })
       .with("scatter", (): ScatterPlotVizConfig => {
         return vizConfig;
+      })
+      .with("pie", (vizType): PieChartVizConfig => {
+        return {
+          vizType,
+          ...pieAxes,
+          isDonut: false,
+          withLabels: true,
+          labelsType: "value",
+        };
+      })
+      .with("funnel", (vizType): FunnelChartVizConfig => {
+        return { vizType, ...pieAxes };
+      })
+      .with("radar", (vizType): RadarChartVizConfig => {
+        return { vizType, ...pieAxes };
+      })
+      .with("bubble", (vizType): BubbleChartVizConfig => {
+        return { vizType, ...xyAxes, sizeKey: undefined };
       })
       .exhaustive(() => {
         throw new Error(`Invalid viz type: ${newVizType}`);

--- a/shared/models/vizs/VizConfig/VizConfig.types.ts
+++ b/shared/models/vizs/VizConfig/VizConfig.types.ts
@@ -1,7 +1,30 @@
-import type { BarChartVizConfig } from "$/models/vizs/BarChartVizConfig/BarChartVizConfig.types.ts";
-import type { LineChartVizConfig } from "$/models/vizs/LineChartVizConfig/LineChartVizConfig.types.ts";
-import type { ScatterPlotVizConfig } from "$/models/vizs/ScatterPlotVizConfig/ScatterPlotVizConfig.types.ts";
-import type { TableVizConfig } from "$/models/vizs/TableVizConfig/TableVizConfig.types.ts";
+import type {
+  AreaChartVizConfig,
+} from "$/models/vizs/AreaChartVizConfig/AreaChartVizConfig.types.ts";
+import type {
+  BarChartVizConfig,
+} from "$/models/vizs/BarChartVizConfig/BarChartVizConfig.types.ts";
+import type {
+  BubbleChartVizConfig,
+} from "$/models/vizs/BubbleChartVizConfig/BubbleChartVizConfig.types.ts";
+import type {
+  FunnelChartVizConfig,
+} from "$/models/vizs/FunnelChartVizConfig/FunnelChartVizConfig.types.ts";
+import type {
+  LineChartVizConfig,
+} from "$/models/vizs/LineChartVizConfig/LineChartVizConfig.types.ts";
+import type {
+  PieChartVizConfig,
+} from "$/models/vizs/PieChartVizConfig/PieChartVizConfig.types.ts";
+import type {
+  RadarChartVizConfig,
+} from "$/models/vizs/RadarChartVizConfig/RadarChartVizConfig.types.ts";
+import type {
+  ScatterPlotVizConfig,
+} from "$/models/vizs/ScatterPlotVizConfig/ScatterPlotVizConfig.types.ts";
+import type {
+  TableVizConfig,
+} from "$/models/vizs/TableVizConfig/TableVizConfig.types.ts";
 import type { IVizConfigModule } from "$/models/vizs/VizConfig/IVizConfigModule.ts";
 import type { ObjectRegistry } from "@utils/types/utilities.types.ts";
 
@@ -9,7 +32,12 @@ export type VizConfig =
   | TableVizConfig
   | BarChartVizConfig
   | LineChartVizConfig
-  | ScatterPlotVizConfig;
+  | AreaChartVizConfig
+  | ScatterPlotVizConfig
+  | PieChartVizConfig
+  | FunnelChartVizConfig
+  | RadarChartVizConfig
+  | BubbleChartVizConfig;
 
 export type VizType = VizConfig["vizType"];
 export type VizConfigRegistry = ObjectRegistry<VizConfig, "vizType">;

--- a/shared/models/vizs/VizConfig/VizConfigs.ts
+++ b/shared/models/vizs/VizConfig/VizConfigs.ts
@@ -1,8 +1,31 @@
 import { registry } from "@utils/objects/registry/registry.ts";
-import { BarChartVizConfigs } from "$/models/vizs/BarChartVizConfig/BarChartVizConfigs.ts";
-import { LineChartVizConfigs } from "$/models/vizs/LineChartVizConfig/LineChartVizConfigs.ts";
-import { ScatterPlotVizConfigs } from "$/models/vizs/ScatterPlotVizConfig/ScatterPlotVizConfigs.ts";
-import { TableVizConfigs } from "$/models/vizs/TableVizConfig/TableVizConfigs.ts";
+import {
+  AreaChartVizConfigs,
+} from "$/models/vizs/AreaChartVizConfig/AreaChartVizConfigs.ts";
+import {
+  BarChartVizConfigs,
+} from "$/models/vizs/BarChartVizConfig/BarChartVizConfigs.ts";
+import {
+  BubbleChartVizConfigs,
+} from "$/models/vizs/BubbleChartVizConfig/BubbleChartVizConfigs.ts";
+import {
+  FunnelChartVizConfigs,
+} from "$/models/vizs/FunnelChartVizConfig/FunnelChartVizConfigs.ts";
+import {
+  LineChartVizConfigs,
+} from "$/models/vizs/LineChartVizConfig/LineChartVizConfigs.ts";
+import {
+  PieChartVizConfigs,
+} from "$/models/vizs/PieChartVizConfig/PieChartVizConfigs.ts";
+import {
+  RadarChartVizConfigs,
+} from "$/models/vizs/RadarChartVizConfig/RadarChartVizConfigs.ts";
+import {
+  ScatterPlotVizConfigs,
+} from "$/models/vizs/ScatterPlotVizConfig/ScatterPlotVizConfigs.ts";
+import {
+  TableVizConfigs,
+} from "$/models/vizs/TableVizConfig/TableVizConfigs.ts";
 import {
   VizConfig,
   VizConfigType,
@@ -10,21 +33,35 @@ import {
   VizType,
 } from "$/models/vizs/VizConfig/VizConfig.types.ts";
 import type { IVizConfigModule } from "$/models/vizs/VizConfig/IVizConfigModule.ts";
-import type { PartialStructuredQuery } from "$/models/queries/StructuredQuery/StructuredQuery.types.ts";
-import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types.ts";
+import type {
+  PartialStructuredQuery,
+} from "$/models/queries/StructuredQuery/StructuredQuery.types.ts";
+import type {
+  QueryResultColumn,
+} from "$/models/queries/QueryResult/QueryResult.types.ts";
 
 const VizConfigModulesRegistry = {
   table: TableVizConfigs,
   bar: BarChartVizConfigs,
   line: LineChartVizConfigs,
+  area: AreaChartVizConfigs,
   scatter: ScatterPlotVizConfigs,
+  pie: PieChartVizConfigs,
+  funnel: FunnelChartVizConfigs,
+  radar: RadarChartVizConfigs,
+  bubble: BubbleChartVizConfigs,
 } as const satisfies VizConfigUtilRegistry;
 
 export const VizTypes = registry<VizType>().keys(
   "table",
   "bar",
   "line",
+  "area",
   "scatter",
+  "pie",
+  "funnel",
+  "radar",
+  "bubble",
 );
 
 /** Get the specific utils module for a given viz type.*/

--- a/shared/models/vizs/applyVizConfigFromQueryResult.test.ts
+++ b/shared/models/vizs/applyVizConfigFromQueryResult.test.ts
@@ -35,6 +35,7 @@ describe("isVizConfigEqualForQueryResultSync", () => {
           vizType: "bar",
           xAxisKey: undefined,
           yAxisKey: undefined,
+          withLegend: true,
         },
       ),
     ).toBe(false);
@@ -45,11 +46,13 @@ describe("isVizConfigEqualForQueryResultSync", () => {
       vizType: "bar" as const,
       xAxisKey: "a",
       yAxisKey: "b",
+      withLegend: true,
     };
     const b = {
       vizType: "bar" as const,
       xAxisKey: "a",
       yAxisKey: "b",
+      withLegend: true,
     };
     expect(isVizConfigEqualForQueryResultSync(a, b)).toBe(true);
   });
@@ -74,6 +77,7 @@ describe("applyVizConfigFromQueryResult", () => {
         vizType: "bar",
         xAxisKey: "gone",
         yAxisKey: "n",
+        withLegend: true,
       },
       rawSQL: undefined,
       query: {
@@ -92,6 +96,7 @@ describe("applyVizConfigFromQueryResult", () => {
         vizType: "bar",
         xAxisKey: undefined,
         yAxisKey: undefined,
+        withLegend: true,
       },
       rawSQL: "SELECT * FROM t",
       query: emptyQuery,
@@ -110,6 +115,7 @@ describe("applyVizConfigFromQueryResult", () => {
         vizType: "bar",
         xAxisKey: "month",
         yAxisKey: "total",
+        withLegend: true,
       },
       rawSQL: "SELECT * FROM t",
       query: emptyQuery,

--- a/shared/models/vizs/applyVizConfigFromQueryResult.ts
+++ b/shared/models/vizs/applyVizConfigFromQueryResult.ts
@@ -1,7 +1,13 @@
-import { shouldHydrateVizFromQueryResult } from "$/models/vizs/shouldHydrateVizFromQueryResult.ts";
+import {
+  shouldHydrateVizFromQueryResult,
+} from "$/models/vizs/shouldHydrateVizFromQueryResult.ts";
 import { VizConfigs } from "$/models/vizs/VizConfig/VizConfigs.ts";
-import type { PartialStructuredQuery } from "$/models/queries/StructuredQuery/StructuredQuery.types.ts";
-import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types.ts";
+import type {
+  PartialStructuredQuery,
+} from "$/models/queries/StructuredQuery/StructuredQuery.types.ts";
+import type {
+  QueryResultColumn,
+} from "$/models/queries/QueryResult/QueryResult.types.ts";
 import type { VizConfig } from "$/models/vizs/VizConfig/VizConfig.types.ts";
 
 type ApplyVizConfigFromQueryResultInput = {
@@ -13,7 +19,7 @@ type ApplyVizConfigFromQueryResultInput = {
 
 /**
  * Returns true when two viz configs match for Data Explorer sync: same viz
- * type and, for XY charts, the same axis keys.
+ * type and, for all non-table viz types, the same primary axis keys.
  */
 export function isVizConfigEqualForQueryResultSync(
   a: VizConfig,
@@ -25,6 +31,20 @@ export function isVizConfigEqualForQueryResultSync(
 
   if (a.vizType === "table") {
     return true;
+  }
+
+  const vt = a.vizType;
+
+  if (vt === "pie" || vt === "funnel" || vt === "radar") {
+    const ap = a as {
+      nameKey: string | undefined;
+      valueKey: string | undefined;
+    };
+    const bp = b as {
+      nameKey: string | undefined;
+      valueKey: string | undefined;
+    };
+    return ap.nameKey === bp.nameKey && ap.valueKey === bp.valueKey;
   }
 
   const ax = a as {
@@ -40,10 +60,10 @@ export function isVizConfigEqualForQueryResultSync(
 }
 
 /**
- * Clears X/Y axis keys missing from the result, then runs
+ * Clears stale axis keys missing from the result, then runs
  * `hydrateFromQueryResult` when `shouldHydrateVizFromQueryResult` is true.
- * **2B:** Skips hydration when both axes remain valid in the result (see
- * `shouldHydrateVizFromQueryResult`).
+ * **2B:** Skips hydration when both primary axes remain valid in the result
+ * (see `shouldHydrateVizFromQueryResult`).
  *
  * @param input Current viz, query context, and result columns.
  * @returns The viz config after validation and optional result hydration.
@@ -60,27 +80,12 @@ export function applyVizConfigFromQueryResult(
 
   let next: VizConfig = vizConfig;
 
-  if (vizConfig.vizType !== "table") {
-    const xy = vizConfig as {
-      xAxisKey: string | undefined;
-      yAxisKey: string | undefined;
-    };
-    let cleared: VizConfig = vizConfig;
-    let didClear = false;
-
-    if (xy.xAxisKey !== undefined && !resultColumnNames.has(xy.xAxisKey)) {
-      cleared = { ...cleared, xAxisKey: undefined } as VizConfig;
-      didClear = true;
-    }
-
-    if (xy.yAxisKey !== undefined && !resultColumnNames.has(xy.yAxisKey)) {
-      cleared = { ...cleared, yAxisKey: undefined } as VizConfig;
-      didClear = true;
-    }
-
-    if (didClear) {
-      next = cleared;
-    }
+  const { config: cleared, didChange } = _clearStaleAxisKeys(
+    vizConfig,
+    resultColumnNames,
+  );
+  if (didChange) {
+    next = cleared;
   }
 
   if (
@@ -95,4 +100,60 @@ export function applyVizConfigFromQueryResult(
   }
 
   return next;
+}
+
+/**
+ * Returns a copy of `vizConfig` with any stale axis keys cleared (i.e.
+ * keys that no longer appear in `resultColumnNames`), plus a flag indicating
+ * whether any key was cleared.
+ */
+function _clearStaleAxisKeys(
+  vizConfig: VizConfig,
+  resultColumnNames: ReadonlySet<string>,
+): { config: VizConfig; didChange: boolean } {
+  if (vizConfig.vizType === "table") {
+    return { config: vizConfig, didChange: false };
+  }
+
+  const vt = vizConfig.vizType;
+
+  if (vt === "pie" || vt === "funnel" || vt === "radar") {
+    const pv = vizConfig as {
+      nameKey: string | undefined;
+      valueKey: string | undefined;
+    };
+    let cleared: VizConfig = vizConfig;
+    let didChange = false;
+
+    if (pv.nameKey !== undefined && !resultColumnNames.has(pv.nameKey)) {
+      cleared = { ...cleared, nameKey: undefined } as VizConfig;
+      didChange = true;
+    }
+
+    if (pv.valueKey !== undefined && !resultColumnNames.has(pv.valueKey)) {
+      cleared = { ...cleared, valueKey: undefined } as VizConfig;
+      didChange = true;
+    }
+
+    return { config: cleared, didChange };
+  }
+
+  const xy = vizConfig as {
+    xAxisKey: string | undefined;
+    yAxisKey: string | undefined;
+  };
+  let cleared: VizConfig = vizConfig;
+  let didChange = false;
+
+  if (xy.xAxisKey !== undefined && !resultColumnNames.has(xy.xAxisKey)) {
+    cleared = { ...cleared, xAxisKey: undefined } as VizConfig;
+    didChange = true;
+  }
+
+  if (xy.yAxisKey !== undefined && !resultColumnNames.has(xy.yAxisKey)) {
+    cleared = { ...cleared, yAxisKey: undefined } as VizConfig;
+    didChange = true;
+  }
+
+  return { config: cleared, didChange };
 }

--- a/shared/models/vizs/hydratePieFromQuery.test.ts
+++ b/shared/models/vizs/hydratePieFromQuery.test.ts
@@ -32,8 +32,8 @@ function makeCol(name: string, dataType: DatasetColumn["dataType"]) {
     id: name as DatasetColumn["id"],
     name,
     dataType,
-    order: 0,
-  });
+    columnIdx: 0,
+  } as DatasetColumn);
 }
 
 function makeQuery(

--- a/shared/models/vizs/hydratePieFromQuery.test.ts
+++ b/shared/models/vizs/hydratePieFromQuery.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { hydratePieFromQuery } from "$/models/vizs/hydratePieFromQuery.ts";
+import {
+  StructuredQuery,
+} from "$/models/queries/StructuredQuery/StructuredQuery.ts";
+import {
+  QueryColumns,
+} from "$/models/queries/QueryColumn/QueryColumns.ts";
+import type {
+  DatasetColumn,
+} from "$/models/datasets/DatasetColumn/DatasetColumn.types.ts";
+import type {
+  PieChartVizConfig,
+} from "$/models/vizs/PieChartVizConfig/PieChartVizConfig.types.ts";
+
+function makePieConfig(
+  overrides: Partial<PieChartVizConfig> = {},
+): PieChartVizConfig {
+  return {
+    vizType: "pie",
+    nameKey: undefined,
+    valueKey: undefined,
+    isDonut: false,
+    withLabels: false,
+    labelsType: "value",
+    ...overrides,
+  };
+}
+
+function makeCol(name: string, dataType: DatasetColumn["dataType"]) {
+  return QueryColumns.makeFromDatasetColumn({
+    id: name as DatasetColumn["id"],
+    name,
+    dataType,
+    order: 0,
+  });
+}
+
+function makeQuery(
+  columns: ReadonlyArray<ReturnType<typeof makeCol>>,
+): ReturnType<typeof StructuredQuery.makeEmpty> {
+  return {
+    ...StructuredQuery.makeEmpty(),
+    queryColumns: columns,
+  };
+}
+
+describe("hydratePieFromQuery", () => {
+  it("picks first non-numeric as nameKey and first numeric as valueKey", () => {
+    const out = hydratePieFromQuery(
+      makePieConfig(),
+      makeQuery([makeCol("category", "varchar"), makeCol("amount", "double")]),
+    );
+    expect(out.nameKey).toBe("category");
+    expect(out.valueKey).toBe("amount");
+  });
+
+  it("falls back to a second numeric nameKey when no non-numeric column", () => {
+    const out = hydratePieFromQuery(
+      makePieConfig(),
+      makeQuery([makeCol("x", "bigint"), makeCol("y", "double")]),
+    );
+    expect(out.valueKey).toBe("x");
+    expect(out.nameKey).toBe("y");
+  });
+
+  it("clears nameKey when the column no longer exists in the query", () => {
+    const out = hydratePieFromQuery(
+      makePieConfig({ nameKey: "stale_col" }),
+      makeQuery([makeCol("category", "varchar"), makeCol("total", "double")]),
+    );
+    expect(out.nameKey).toBe("category");
+  });
+
+  it("does not overwrite already valid keys", () => {
+    const out = hydratePieFromQuery(
+      makePieConfig({ nameKey: "category", valueKey: "total" }),
+      makeQuery([makeCol("category", "varchar"), makeCol("total", "double")]),
+    );
+    expect(out.nameKey).toBe("category");
+    expect(out.valueKey).toBe("total");
+  });
+
+  it("returns unchanged when the query has no columns", () => {
+    const cfg = makePieConfig();
+    expect(hydratePieFromQuery(cfg, makeQuery([]))).toEqual(cfg);
+  });
+});

--- a/shared/models/vizs/hydratePieFromQuery.ts
+++ b/shared/models/vizs/hydratePieFromQuery.ts
@@ -1,0 +1,78 @@
+import { isNonEmptyArray } from "@utils/guards/isNonEmptyArray/isNonEmptyArray.ts";
+import { QueryColumns } from "$/models/queries/QueryColumn/QueryColumns.ts";
+import type {
+  PartialStructuredQuery,
+} from "$/models/queries/StructuredQuery/StructuredQuery.types.ts";
+
+type PieAxesConfig = {
+  nameKey: string | undefined;
+  valueKey: string | undefined;
+};
+
+/**
+ * Hydrate `nameKey` and `valueKey` from a structured query's columns.
+ *
+ * Clears any existing key that no longer appears in the query, then fills
+ * undefined keys: `valueKey` ← first numeric column; `nameKey` ← first
+ * non-numeric column that is not the value key.
+ *
+ * @param currVizConfig The current pie-like viz config.
+ * @param query The structured query to hydrate from.
+ * @returns Updated config with hydrated keys.
+ */
+export function hydratePieFromQuery<VConfig extends PieAxesConfig>(
+  currVizConfig: VConfig,
+  query: PartialStructuredQuery,
+): VConfig {
+  const { queryColumns } = query;
+
+  const isNameKeyValid = queryColumns.some((col) => {
+    return QueryColumns.getDerivedColumnName(col) === currVizConfig.nameKey;
+  });
+  const isValueKeyValid = queryColumns.some((col) => {
+    return QueryColumns.getDerivedColumnName(col) === currVizConfig.valueKey;
+  });
+
+  let next: VConfig = {
+    ...currVizConfig,
+    nameKey: isNameKeyValid ? currVizConfig.nameKey : undefined,
+    valueKey: isValueKeyValid ? currVizConfig.valueKey : undefined,
+  };
+
+  if (
+    (next.nameKey === undefined || next.valueKey === undefined) &&
+    isNonEmptyArray(queryColumns)
+  ) {
+    if (next.valueKey === undefined) {
+      const firstNumericCol = queryColumns.find(QueryColumns.isNumeric);
+      next = {
+        ...next,
+        valueKey: firstNumericCol ?
+          QueryColumns.getDerivedColumnName(firstNumericCol)
+        : undefined,
+      };
+    }
+
+    if (next.nameKey === undefined) {
+      const valueKey = next.valueKey;
+      const firstNonNumericCol = queryColumns.find((col) => {
+        return (
+          !QueryColumns.isNumeric(col) &&
+          QueryColumns.getDerivedColumnName(col) !== valueKey
+        );
+      });
+      const fallbackCol = queryColumns.find((col) => {
+        return QueryColumns.getDerivedColumnName(col) !== valueKey;
+      });
+      const nameCol = firstNonNumericCol ?? fallbackCol;
+      next = {
+        ...next,
+        nameKey: nameCol ?
+          QueryColumns.getDerivedColumnName(nameCol)
+        : undefined,
+      };
+    }
+  }
+
+  return next;
+}

--- a/shared/models/vizs/hydratePieFromQueryResult.test.ts
+++ b/shared/models/vizs/hydratePieFromQueryResult.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  hydratePieFromQueryResult,
+} from "$/models/vizs/hydratePieFromQueryResult.ts";
+import type {
+  QueryResultColumn,
+} from "$/models/queries/QueryResult/QueryResult.types.ts";
+
+function cols(
+  pairs: ReadonlyArray<{
+    name: string;
+    dataType: QueryResultColumn["dataType"];
+  }>,
+): QueryResultColumn[] {
+  return pairs.map((p) => {
+    return { name: p.name, dataType: p.dataType };
+  });
+}
+
+describe("hydratePieFromQueryResult", () => {
+  const empty = { nameKey: undefined, valueKey: undefined };
+
+  it("picks temporal nameKey and numeric valueKey", () => {
+    const out = hydratePieFromQueryResult(
+      { ...empty },
+      cols([
+        { name: "month", dataType: "timestamp" },
+        { name: "total_cases", dataType: "double" },
+      ]),
+    );
+    expect(out.nameKey).toBe("month");
+    expect(out.valueKey).toBe("total_cases");
+  });
+
+  it("prefers text nameKey over numeric fallback", () => {
+    const out = hydratePieFromQueryResult(
+      { ...empty },
+      cols([
+        { name: "total", dataType: "double" },
+        { name: "region", dataType: "varchar" },
+      ]),
+    );
+    expect(out.valueKey).toBe("total");
+    expect(out.nameKey).toBe("region");
+  });
+
+  it("falls back to a second numeric when no categorical column", () => {
+    const out = hydratePieFromQueryResult(
+      { ...empty },
+      cols([
+        { name: "a", dataType: "bigint" },
+        { name: "b", dataType: "double" },
+      ]),
+    );
+    expect(out.valueKey).toBe("a");
+    expect(out.nameKey).toBe("b");
+  });
+
+  it("does not overwrite preset keys", () => {
+    const out = hydratePieFromQueryResult(
+      { nameKey: "custom_name", valueKey: "custom_value" },
+      cols([
+        { name: "cat", dataType: "varchar" },
+        { name: "num", dataType: "double" },
+      ]),
+    );
+    expect(out.nameKey).toBe("custom_name");
+    expect(out.valueKey).toBe("custom_value");
+  });
+
+  it("returns unchanged when columns is empty", () => {
+    const cfg = { nameKey: undefined, valueKey: undefined };
+    expect(hydratePieFromQueryResult(cfg, [])).toEqual(cfg);
+  });
+
+  it("leaves valueKey undefined when there is no numeric column", () => {
+    const out = hydratePieFromQueryResult(
+      { ...empty },
+      cols([{ name: "label", dataType: "varchar" }]),
+    );
+    expect(out.valueKey).toBeUndefined();
+  });
+});

--- a/shared/models/vizs/hydratePieFromQueryResult.ts
+++ b/shared/models/vizs/hydratePieFromQueryResult.ts
@@ -1,0 +1,75 @@
+import { AvaDataTypes } from "$/models/datasets/AvaDataType/AvaDataTypes.ts";
+import type {
+  QueryResultColumn,
+} from "$/models/queries/QueryResult/QueryResult.types.ts";
+
+type PieAxesConfig = {
+  nameKey: string | undefined;
+  valueKey: string | undefined;
+};
+
+/**
+ * Hydrate `nameKey` and `valueKey` from query result column metadata when
+ * they are undefined. Does not overwrite keys that are already set.
+ *
+ * `valueKey` ← first numeric column;
+ * `nameKey` ← first temporal, then text, then boolean, then any remaining
+ * column that is not the value key.
+ *
+ * @param currVizConfig The current pie-like viz config.
+ * @param columns Result columns with names and `AvaDataType`.
+ * @returns Updated config with any newly inferred keys.
+ */
+export function hydratePieFromQueryResult<VConfig extends PieAxesConfig>(
+  currVizConfig: VConfig,
+  columns: readonly QueryResultColumn[],
+): VConfig {
+  if (columns.length === 0) {
+    return currVizConfig;
+  }
+
+  let next: VConfig = { ...currVizConfig };
+
+  if (next.valueKey === undefined) {
+    const valueCol = columns.find((c) => {
+      return AvaDataTypes.isNumeric(c.dataType);
+    });
+    if (valueCol !== undefined) {
+      next = { ...next, valueKey: valueCol.name };
+    }
+  }
+
+  if (next.nameKey === undefined) {
+    const valueKey = next.valueKey;
+    const others = columns.filter((c) => {
+      return c.name !== valueKey;
+    });
+
+    const temporal = others.find((c) => {
+      return AvaDataTypes.isTemporal(c.dataType);
+    });
+    if (temporal !== undefined) {
+      return { ...next, nameKey: temporal.name };
+    }
+
+    const text = others.find((c) => {
+      return AvaDataTypes.isText(c.dataType);
+    });
+    if (text !== undefined) {
+      return { ...next, nameKey: text.name };
+    }
+
+    const booleanCol = others.find((c) => {
+      return c.dataType === "boolean";
+    });
+    if (booleanCol !== undefined) {
+      return { ...next, nameKey: booleanCol.name };
+    }
+
+    if (others[0] !== undefined) {
+      return { ...next, nameKey: others[0].name };
+    }
+  }
+
+  return next;
+}

--- a/shared/models/vizs/shouldHydrateVizFromQueryResult.test.ts
+++ b/shared/models/vizs/shouldHydrateVizFromQueryResult.test.ts
@@ -28,6 +28,7 @@ describe("shouldHydrateVizFromQueryResult", () => {
     vizType: "bar",
     xAxisKey: undefined,
     yAxisKey: undefined,
+    withLegend: true,
   };
 
   it("returns false for table viz", () => {
@@ -61,6 +62,7 @@ describe("shouldHydrateVizFromQueryResult", () => {
           vizType: "bar",
           xAxisKey: "month",
           yAxisKey: "total",
+          withLegend: true,
         },
         resultColumnNames: new Set(["month", "total"]),
       }),
@@ -79,6 +81,7 @@ describe("shouldHydrateVizFromQueryResult", () => {
           vizType: "bar",
           xAxisKey: "month",
           yAxisKey: "total_cases",
+          withLegend: true,
         },
         resultColumnNames: new Set(["month", "total_cases"]),
       }),
@@ -105,6 +108,7 @@ describe("shouldHydrateVizFromQueryResult", () => {
           vizType: "bar",
           xAxisKey: "old_x",
           yAxisKey: "y",
+          withLegend: true,
         },
         resultColumnNames: new Set(["month", "y"]),
       }),
@@ -134,6 +138,8 @@ describe("shouldHydrateVizFromQueryResult", () => {
           vizType: "line",
           xAxisKey: "month",
           yAxisKey: "total_cases",
+          withLegend: true,
+          curveType: "monotone",
         },
         resultColumnNames: new Set(["month", "total_cases"]),
       }),

--- a/shared/models/vizs/shouldHydrateVizFromQueryResult.ts
+++ b/shared/models/vizs/shouldHydrateVizFromQueryResult.ts
@@ -1,5 +1,7 @@
 import { QueryColumns } from "$/models/queries/QueryColumn/QueryColumns.ts";
-import type { PartialStructuredQuery } from "$/models/queries/StructuredQuery/StructuredQuery.types.ts";
+import type {
+  PartialStructuredQuery,
+} from "$/models/queries/StructuredQuery/StructuredQuery.types.ts";
 import type { VizConfig } from "$/models/vizs/VizConfig/VizConfig.types.ts";
 
 type Options = {
@@ -13,15 +15,15 @@ type Options = {
 /**
  * Whether the app should run `hydrateFromQueryResult` for the current viz.
  *
- * True when structured `hydrateFromQuery` cannot reliably drive XY axes: raw
+ * True when structured `hydrateFromQuery` cannot reliably drive axes: raw
  * SQL path, no structured columns, axis keys missing from the result, or no
  * overlap between structured derived column names and result names.
  *
- * **2B:** When both X and Y are set and each name still appears in the result,
- * returns false so we do not re-invoke result hydration on every refetch
- * (manual axis choices preserved across identical schemas).
+ * **2B:** When all primary axis keys are set and each name still appears in
+ * the result, returns false so we do not re-invoke result hydration on every
+ * refetch (manual axis choices preserved across identical schemas).
  *
- * Table viz returns false (no XY axes to infer here).
+ * Table viz returns false (no axis keys to infer here).
  */
 export function shouldHydrateVizFromQueryResult(options: Options): boolean {
   const { rawSQL, query, vizConfig, resultColumnNames } = options;
@@ -30,16 +32,13 @@ export function shouldHydrateVizFromQueryResult(options: Options): boolean {
     return false;
   }
 
-  const xy = vizConfig as {
-    xAxisKey: string | undefined;
-    yAxisKey: string | undefined;
-  };
+  const { key1, key2 } = _getPrimaryAxisKeys(vizConfig);
 
   if (
-    xy.xAxisKey !== undefined &&
-    xy.yAxisKey !== undefined &&
-    resultColumnNames.has(xy.xAxisKey) &&
-    resultColumnNames.has(xy.yAxisKey)
+    key1 !== undefined &&
+    key2 !== undefined &&
+    resultColumnNames.has(key1) &&
+    resultColumnNames.has(key2)
   ) {
     return false;
   }
@@ -52,11 +51,11 @@ export function shouldHydrateVizFromQueryResult(options: Options): boolean {
     return true;
   }
 
-  if (xy.xAxisKey !== undefined && !resultColumnNames.has(xy.xAxisKey)) {
+  if (key1 !== undefined && !resultColumnNames.has(key1)) {
     return true;
   }
 
-  if (xy.yAxisKey !== undefined && !resultColumnNames.has(xy.yAxisKey)) {
+  if (key2 !== undefined && !resultColumnNames.has(key2)) {
     return true;
   }
 
@@ -72,4 +71,30 @@ export function shouldHydrateVizFromQueryResult(options: Options): boolean {
   }
 
   return false;
+}
+
+/**
+ * Returns the two "primary" axis keys for a given viz config.
+ * - Pie-like (pie, funnel, radar): nameKey + valueKey
+ * - All others: xAxisKey + yAxisKey
+ */
+function _getPrimaryAxisKeys(vizConfig: VizConfig): {
+  key1: string | undefined;
+  key2: string | undefined;
+} {
+  const vt = vizConfig.vizType;
+
+  if (vt === "pie" || vt === "funnel" || vt === "radar") {
+    const pv = vizConfig as {
+      nameKey: string | undefined;
+      valueKey: string | undefined;
+    };
+    return { key1: pv.nameKey, key2: pv.valueKey };
+  }
+
+  const xy = vizConfig as {
+    xAxisKey: string | undefined;
+    yAxisKey: string | undefined;
+  };
+  return { key1: xy.xAxisKey, key2: xy.yAxisKey };
 }

--- a/src/lib/ui/viz/AreaChart.tsx
+++ b/src/lib/ui/viz/AreaChart.tsx
@@ -33,6 +33,7 @@ import type { XYChartProps } from "@/lib/ui/viz/ChartTypes";
 type Props = XYChartProps & {
   withLegend?: boolean;
   curveType?: CurveType;
+  color?: string;
 };
 
 export function AreaChart({
@@ -45,6 +46,7 @@ export function AreaChart({
   timezone,
   withLegend = false,
   curveType = "monotone",
+  color = "var(--mantine-color-blue-6)",
 }: Props): JSX.Element {
   const gradientId = useId();
   const isDateAxis = dateColumns?.has(xAxisKey) ?? false;
@@ -76,16 +78,8 @@ export function AreaChart({
         >
           <defs>
             <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-              <stop
-                offset="0%"
-                stopColor="var(--mantine-color-blue-6)"
-                stopOpacity={0.2}
-              />
-              <stop
-                offset="100%"
-                stopColor="var(--mantine-color-blue-6)"
-                stopOpacity={0.01}
-              />
+              <stop offset="0%" stopColor={color} stopOpacity={0.2} />
+              <stop offset="100%" stopColor={color} stopOpacity={0.01} />
             </linearGradient>
           </defs>
           <CartesianGrid
@@ -113,18 +107,14 @@ export function AreaChart({
           <Area
             type={curveType}
             dataKey={yAxisKey}
-            stroke="var(--mantine-color-blue-6)"
+            stroke={color}
             strokeWidth={2}
             fill={`url(#${gradientId})`}
-            dot={{
-              r: 4,
-              fill: "var(--mantine-color-blue-6)",
-              strokeWidth: 0,
-            }}
+            dot={{ r: 4, fill: color, strokeWidth: 0 }}
             activeDot={{
               r: 5,
               fill: "white",
-              stroke: "var(--mantine-color-blue-6)",
+              stroke: color,
               strokeWidth: 2,
             }}
           />

--- a/src/lib/ui/viz/AreaChart.tsx
+++ b/src/lib/ui/viz/AreaChart.tsx
@@ -1,0 +1,135 @@
+/**
+ * NOTE: This component uses Recharts directly instead of Mantine's
+ * `AreaChart` wrapper. Mantine's wrapper wraps each series' gradient `<defs>`
+ * and fill `Area` together in a React Fragment before handing the children to
+ * Recharts. Recharts resolves graphical elements by reference inside
+ * `filterFormatItem` (generateCategoricalChart.js), and the Fragment wrapping
+ * causes the fill+stroke `Area` to be un-matched at render time — leaving
+ * only the dots-only `Area` visible (dots, no line, no fill). The `areaProps`
+ * escape hatch does not help because `withDots={false}` removes the only Area
+ * that was successfully matching, resulting in a completely blank chart.
+ *
+ * Using Recharts directly avoids the Fragment wrapping issue entirely. The
+ * external component API is identical to every other chart wrapper in this
+ * directory, so nothing outside this file is affected.
+ */
+import {
+  Area,
+  AreaChart as RechartsAreaChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Box } from "@mantine/core";
+import { formatDate } from "@utils/dates/formatDate/formatDate";
+import { useId, useMemo } from "react";
+import { X_AXIS_PADDING } from "@/lib/ui/viz/ChartConstants";
+import type { CurveType } from "$/models/vizs/CurveType";
+import type { XYChartProps } from "@/lib/ui/viz/ChartTypes";
+
+type Props = XYChartProps & {
+  withLegend?: boolean;
+  curveType?: CurveType;
+};
+
+export function AreaChart({
+  data,
+  xAxisKey,
+  yAxisKey,
+  height = 500,
+  dateColumns,
+  dateFormat = "YYYY-MM-DD",
+  timezone,
+  withLegend = false,
+  curveType = "monotone",
+}: Props): JSX.Element {
+  const gradientId = useId();
+  const isDateAxis = dateColumns?.has(xAxisKey) ?? false;
+
+  const tickFormatter = useMemo(() => {
+    if (!isDateAxis) {
+      return undefined;
+    }
+    return (value: unknown) => {
+      return formatDate(value, { format: dateFormat, zone: timezone });
+    };
+  }, [isDateAxis, dateFormat, timezone]);
+
+  const labelFormatter = useMemo(() => {
+    if (!isDateAxis) {
+      return undefined;
+    }
+    return (label: unknown) => {
+      return formatDate(label, { format: dateFormat, zone: timezone });
+    };
+  }, [isDateAxis, dateFormat, timezone]);
+
+  return (
+    <Box h={height} w="100%">
+      <ResponsiveContainer width="100%" height="100%">
+        <RechartsAreaChart
+          data={data as Array<Record<string, unknown>>}
+          margin={{ top: 10, right: 10, bottom: 0, left: 0 }}
+        >
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop
+                offset="0%"
+                stopColor="var(--mantine-color-blue-6)"
+                stopOpacity={0.2}
+              />
+              <stop
+                offset="100%"
+                stopColor="var(--mantine-color-blue-6)"
+                stopOpacity={0.01}
+              />
+            </linearGradient>
+          </defs>
+          <CartesianGrid
+            strokeDasharray="5 5"
+            vertical={false}
+            stroke="var(--mantine-color-gray-3)"
+          />
+          <XAxis
+            dataKey={xAxisKey}
+            padding={X_AXIS_PADDING}
+            tickFormatter={tickFormatter}
+            tick={{ fontSize: 12, fill: "currentColor" }}
+            stroke=""
+            tickLine={false}
+            interval="preserveStartEnd"
+            minTickGap={5}
+          />
+          <YAxis
+            tick={{ fontSize: 12, fill: "currentColor" }}
+            stroke=""
+            tickLine={false}
+          />
+          {withLegend ? <Legend verticalAlign="top" /> : null}
+          <Tooltip labelFormatter={labelFormatter} />
+          <Area
+            type={curveType}
+            dataKey={yAxisKey}
+            stroke="var(--mantine-color-blue-6)"
+            strokeWidth={2}
+            fill={`url(#${gradientId})`}
+            dot={{
+              r: 4,
+              fill: "var(--mantine-color-blue-6)",
+              strokeWidth: 0,
+            }}
+            activeDot={{
+              r: 5,
+              fill: "white",
+              stroke: "var(--mantine-color-blue-6)",
+              strokeWidth: 2,
+            }}
+          />
+        </RechartsAreaChart>
+      </ResponsiveContainer>
+    </Box>
+  );
+}

--- a/src/lib/ui/viz/BarChart.tsx
+++ b/src/lib/ui/viz/BarChart.tsx
@@ -6,6 +6,7 @@ import type { XYChartProps } from "@/lib/ui/viz/ChartTypes";
 
 type Props = XYChartProps & {
   withLegend?: boolean;
+  color?: string;
 };
 
 export function BarChart({
@@ -17,10 +18,11 @@ export function BarChart({
   dateFormat = "YYYY-MM-DD",
   timezone,
   withLegend = false,
+  color,
 }: Props): JSX.Element {
   const series = useMemo(() => {
-    return [{ name: yAxisKey }];
-  }, [yAxisKey]);
+    return [{ name: yAxisKey, ...(color ? { color } : {}) }];
+  }, [yAxisKey, color]);
 
   const isDateAxis = dateColumns?.has(xAxisKey) ?? false;
 

--- a/src/lib/ui/viz/BarChart.tsx
+++ b/src/lib/ui/viz/BarChart.tsx
@@ -4,6 +4,10 @@ import { useMemo } from "react";
 import { X_AXIS_PADDING } from "@/lib/ui/viz/ChartConstants";
 import type { XYChartProps } from "@/lib/ui/viz/ChartTypes";
 
+type Props = XYChartProps & {
+  withLegend?: boolean;
+};
+
 export function BarChart({
   data,
   xAxisKey,
@@ -12,7 +16,8 @@ export function BarChart({
   dateColumns,
   dateFormat = "YYYY-MM-DD",
   timezone,
-}: XYChartProps): JSX.Element {
+  withLegend = false,
+}: Props): JSX.Element {
   const series = useMemo(() => {
     return [{ name: yAxisKey }];
   }, [yAxisKey]);
@@ -50,6 +55,7 @@ export function BarChart({
       series={series}
       xAxisProps={xAxisProps}
       tooltipProps={tooltipProps}
+      withLegend={withLegend}
     />
   );
 }

--- a/src/lib/ui/viz/BubbleChart.tsx
+++ b/src/lib/ui/viz/BubbleChart.tsx
@@ -1,0 +1,33 @@
+import { BubbleChart as MantineBubbleChart } from "@mantine/charts";
+import { useMemo } from "react";
+import { BUBBLE_SIZE_RANGE } from "@/lib/ui/viz/ChartConstants";
+import type { UnknownDataFrame } from "@utils/types/common.types";
+
+type Props = {
+  data: UnknownDataFrame;
+  xAxisKey: string;
+  yAxisKey: string;
+  sizeKey: string;
+  height?: number;
+};
+
+export function BubbleChart({
+  data,
+  xAxisKey,
+  yAxisKey,
+  sizeKey,
+  height = 500,
+}: Props): JSX.Element {
+  const dataKey = useMemo(() => {
+    return { x: xAxisKey, y: yAxisKey, z: sizeKey };
+  }, [xAxisKey, yAxisKey, sizeKey]);
+
+  return (
+    <MantineBubbleChart
+      h={height}
+      data={data as Array<Record<string, unknown>>}
+      dataKey={dataKey}
+      range={BUBBLE_SIZE_RANGE}
+    />
+  );
+}

--- a/src/lib/ui/viz/ChartConstants.ts
+++ b/src/lib/ui/viz/ChartConstants.ts
@@ -3,3 +3,26 @@
  * tick labels are not clipped by the chart container edge.
  */
 export const X_AXIS_PADDING = { left: 30, right: 30 } as const;
+
+/**
+ * Bubble size range [minArea, maxArea] in pixels² passed to Recharts ZAxis.
+ * Maps the smallest z value to ~10px radius and largest to ~32px radius.
+ */
+export const BUBBLE_SIZE_RANGE: [number, number] = [100, 3200] as const;
+
+/**
+ * Fixed color cycle used for pie, donut, funnel, and radar chart slices.
+ * Expressed as Mantine color strings (e.g. `"blue.6"`).
+ */
+export const CHART_COLORS = [
+  "blue.6",
+  "teal.6",
+  "yellow.6",
+  "orange.6",
+  "red.6",
+  "grape.6",
+  "indigo.6",
+  "cyan.6",
+  "green.6",
+  "pink.6",
+] as const;

--- a/src/lib/ui/viz/ChartConstants.ts
+++ b/src/lib/ui/viz/ChartConstants.ts
@@ -11,6 +11,23 @@ export const X_AXIS_PADDING = { left: 30, right: 30 } as const;
 export const BUBBLE_SIZE_RANGE: [number, number] = [100, 3200] as const;
 
 /**
+ * Swatches matching CHART_COLORS for use in ColorInput components.
+ * Uses Mantine CSS variables so they stay in sync with the theme.
+ */
+export const CHART_COLOR_SWATCHES = [
+  "#228be6", // blue.6
+  "#12b886", // teal.6
+  "#fab005", // yellow.6
+  "#fd7e14", // orange.6
+  "#fa5252", // red.6
+  "#be4bdb", // grape.6
+  "#4c6ef5", // indigo.6
+  "#15aabf", // cyan.6
+  "#40c057", // green.6
+  "#e64980", // pink.6
+];
+
+/**
  * Fixed color cycle used for pie, donut, funnel, and radar chart slices.
  * Expressed as Mantine color strings (e.g. `"blue.6"`).
  */

--- a/src/lib/ui/viz/FunnelChart.tsx
+++ b/src/lib/ui/viz/FunnelChart.tsx
@@ -1,0 +1,31 @@
+import { FunnelChart as MantineFunnelChart } from "@mantine/charts";
+import { useMemo } from "react";
+import { CHART_COLORS } from "@/lib/ui/viz/ChartConstants";
+import type { UnknownDataFrame } from "@utils/types/common.types";
+
+type Props = {
+  data: UnknownDataFrame;
+  nameKey: string;
+  valueKey: string;
+  size?: number;
+};
+
+export function FunnelChart({
+  data,
+  nameKey,
+  valueKey,
+  size = 300,
+}: Props): JSX.Element {
+  const chartData = useMemo(() => {
+    return data.map((row, index) => {
+      const r = row as Record<string, unknown>;
+      return {
+        name: String(r[nameKey] ?? ""),
+        value: Number(r[valueKey] ?? 0),
+        color: CHART_COLORS[index % CHART_COLORS.length],
+      };
+    });
+  }, [data, nameKey, valueKey]);
+
+  return <MantineFunnelChart data={chartData} size={size} withLabels />;
+}

--- a/src/lib/ui/viz/FunnelChart.tsx
+++ b/src/lib/ui/viz/FunnelChart.tsx
@@ -7,6 +7,7 @@ type Props = {
   data: UnknownDataFrame;
   nameKey: string;
   valueKey: string;
+  seriesColors?: Record<string, string>;
   size?: number;
 };
 
@@ -14,18 +15,23 @@ export function FunnelChart({
   data,
   nameKey,
   valueKey,
+  seriesColors,
   size = 300,
 }: Props): JSX.Element {
   const chartData = useMemo(() => {
     return data.map((row, index) => {
       const r = row as Record<string, unknown>;
+      const name = String(r[nameKey] ?? "");
       return {
-        name: String(r[nameKey] ?? ""),
+        name,
         value: Number(r[valueKey] ?? 0),
-        color: CHART_COLORS[index % CHART_COLORS.length],
+        color:
+          seriesColors?.[name] ??
+          CHART_COLORS[index % CHART_COLORS.length] ??
+          "blue.6",
       };
     });
-  }, [data, nameKey, valueKey]);
+  }, [data, nameKey, valueKey, seriesColors]);
 
   return <MantineFunnelChart data={chartData} size={size} withLabels />;
 }

--- a/src/lib/ui/viz/LineChart.tsx
+++ b/src/lib/ui/viz/LineChart.tsx
@@ -2,7 +2,13 @@ import { LineChart as MantineLineChart } from "@mantine/charts";
 import { formatDate } from "@utils/dates/formatDate/formatDate";
 import { useMemo } from "react";
 import { X_AXIS_PADDING } from "@/lib/ui/viz/ChartConstants";
+import type { CurveType } from "$/models/vizs/CurveType";
 import type { XYChartProps } from "@/lib/ui/viz/ChartTypes";
+
+type Props = XYChartProps & {
+  withLegend?: boolean;
+  curveType?: CurveType;
+};
 
 export function LineChart({
   data,
@@ -12,7 +18,9 @@ export function LineChart({
   dateColumns,
   dateFormat = "YYYY-MM-DD",
   timezone,
-}: XYChartProps): JSX.Element {
+  withLegend = false,
+  curveType = "monotone",
+}: Props): JSX.Element {
   const series = useMemo(() => {
     return [{ name: yAxisKey }];
   }, [yAxisKey]);
@@ -50,6 +58,8 @@ export function LineChart({
       series={series}
       xAxisProps={xAxisProps}
       tooltipProps={tooltipProps}
+      withLegend={withLegend}
+      curveType={curveType}
     />
   );
 }

--- a/src/lib/ui/viz/LineChart.tsx
+++ b/src/lib/ui/viz/LineChart.tsx
@@ -8,6 +8,7 @@ import type { XYChartProps } from "@/lib/ui/viz/ChartTypes";
 type Props = XYChartProps & {
   withLegend?: boolean;
   curveType?: CurveType;
+  color?: string;
 };
 
 export function LineChart({
@@ -20,10 +21,11 @@ export function LineChart({
   timezone,
   withLegend = false,
   curveType = "monotone",
+  color,
 }: Props): JSX.Element {
   const series = useMemo(() => {
-    return [{ name: yAxisKey }];
-  }, [yAxisKey]);
+    return [{ name: yAxisKey, ...(color ? { color } : {}) }];
+  }, [yAxisKey, color]);
 
   const isDateAxis = dateColumns?.has(xAxisKey) ?? false;
 

--- a/src/lib/ui/viz/PieChart.tsx
+++ b/src/lib/ui/viz/PieChart.tsx
@@ -1,0 +1,58 @@
+import {
+  DonutChart,
+  PieChart as MantinePieChart,
+} from "@mantine/charts";
+import { useMemo } from "react";
+import { CHART_COLORS } from "@/lib/ui/viz/ChartConstants";
+import type { UnknownDataFrame } from "@utils/types/common.types";
+
+type Props = {
+  data: UnknownDataFrame;
+  nameKey: string;
+  valueKey: string;
+  isDonut: boolean;
+  withLabels: boolean;
+  labelsType: "value" | "percent";
+  size?: number;
+};
+
+export function PieChart({
+  data,
+  nameKey,
+  valueKey,
+  isDonut,
+  withLabels,
+  labelsType,
+  size = 300,
+}: Props): JSX.Element {
+  const chartData = useMemo(() => {
+    return data.map((row, index) => {
+      const r = row as Record<string, unknown>;
+      return {
+        name: String(r[nameKey] ?? ""),
+        value: Number(r[valueKey] ?? 0),
+        color: CHART_COLORS[index % CHART_COLORS.length],
+      };
+    });
+  }, [data, nameKey, valueKey]);
+
+  if (isDonut) {
+    return (
+      <DonutChart
+        data={chartData}
+        size={size}
+        withLabels={withLabels}
+        labelsType={labelsType}
+      />
+    );
+  }
+
+  return (
+    <MantinePieChart
+      data={chartData}
+      size={size}
+      withLabels={withLabels}
+      labelsType={labelsType}
+    />
+  );
+}

--- a/src/lib/ui/viz/PieChart.tsx
+++ b/src/lib/ui/viz/PieChart.tsx
@@ -13,6 +13,7 @@ type Props = {
   isDonut: boolean;
   withLabels: boolean;
   labelsType: "value" | "percent";
+  seriesColors?: Record<string, string>;
   size?: number;
 };
 
@@ -23,18 +24,23 @@ export function PieChart({
   isDonut,
   withLabels,
   labelsType,
+  seriesColors,
   size = 300,
 }: Props): JSX.Element {
   const chartData = useMemo(() => {
     return data.map((row, index) => {
       const r = row as Record<string, unknown>;
+      const name = String(r[nameKey] ?? "");
       return {
-        name: String(r[nameKey] ?? ""),
+        name,
         value: Number(r[valueKey] ?? 0),
-        color: CHART_COLORS[index % CHART_COLORS.length],
+        color:
+          seriesColors?.[name] ??
+          CHART_COLORS[index % CHART_COLORS.length] ??
+          "blue.6",
       };
     });
-  }, [data, nameKey, valueKey]);
+  }, [data, nameKey, valueKey, seriesColors]);
 
   if (isDonut) {
     return (

--- a/src/lib/ui/viz/RadarChart.tsx
+++ b/src/lib/ui/viz/RadarChart.tsx
@@ -6,6 +6,7 @@ type Props = {
   data: UnknownDataFrame;
   nameKey: string;
   valueKey: string;
+  color?: string;
   height?: number;
 };
 
@@ -13,11 +14,12 @@ export function RadarChart({
   data,
   nameKey,
   valueKey,
+  color = "blue.6",
   height = 300,
 }: Props): JSX.Element {
   const series = useMemo(() => {
-    return [{ name: valueKey, color: "blue.6", opacity: 0.2 }];
-  }, [valueKey]);
+    return [{ name: valueKey, color, opacity: 0.2 }];
+  }, [valueKey, color]);
 
   return (
     <MantineRadarChart

--- a/src/lib/ui/viz/RadarChart.tsx
+++ b/src/lib/ui/viz/RadarChart.tsx
@@ -1,0 +1,33 @@
+import { RadarChart as MantineRadarChart } from "@mantine/charts";
+import { useMemo } from "react";
+import type { UnknownDataFrame } from "@utils/types/common.types";
+
+type Props = {
+  data: UnknownDataFrame;
+  nameKey: string;
+  valueKey: string;
+  height?: number;
+};
+
+export function RadarChart({
+  data,
+  nameKey,
+  valueKey,
+  height = 300,
+}: Props): JSX.Element {
+  const series = useMemo(() => {
+    return [{ name: valueKey, color: "blue.6", opacity: 0.2 }];
+  }, [valueKey]);
+
+  return (
+    <MantineRadarChart
+      h={height}
+      w="100%"
+      data={data as Array<Record<string, unknown>>}
+      dataKey={nameKey}
+      series={series}
+      withTooltip
+      withLegend
+    />
+  );
+}

--- a/src/routes/_auth/$workspaceSlug/data-explorer.tsx
+++ b/src/routes/_auth/$workspaceSlug/data-explorer.tsx
@@ -1,10 +1,14 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { DataExplorerSearchSchema } from "@/views/DataExplorerApp/DataExplorerURLState";
 import { DataExplorerApp } from "@/views/DataExplorerApp/DataExplorerApp";
 
 export const Route = createFileRoute("/_auth/$workspaceSlug/data-explorer")({
   component: RouteComponent,
+  validateSearch: DataExplorerSearchSchema,
 });
 
 function RouteComponent() {
-  return <DataExplorerApp />;
+  const urlSearch = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  return <DataExplorerApp urlSearch={urlSearch} navigate={navigate} />;
 }

--- a/src/views/DataExplorerApp/DataExplorerApp.tsx
+++ b/src/views/DataExplorerApp/DataExplorerApp.tsx
@@ -7,33 +7,74 @@ import {
   MantineTheme,
   Menu,
   Stack,
+  Text,
 } from "@mantine/core";
 import { modals } from "@mantine/modals";
 import {
   IconChevronDown,
   IconDownload,
+  IconFolderOpen,
   IconInfoCircle,
+  IconRotateClockwise,
 } from "@tabler/icons-react";
 import { useEffect, useMemo } from "react";
-import { notifyError, notifyNotImplemented } from "@ui/index";
+import { notifyError, notifyNotImplemented, notifySuccess } from "@ui/index";
 import { Tooltip } from "@ui/Tooltip/Tooltip";
 import { isEpochMs, isISODateString, prop } from "@utils/index";
 import { AvaDataTypes } from "$/models/datasets/AvaDataType/AvaDataTypes";
 import { AppLayout } from "@/components/common/layouts/AppLayout/AppLayout";
 import { useCurrentWorkspace } from "@/hooks/workspaces/useCurrentWorkspace";
+import { DatasetClient } from "@/clients/datasets/DatasetClient";
+import { VirtualDatasetClient } from "@/clients/datasets/VirtualDatasetClient";
 import { DataExplorerStateManager } from "@/views/DataExplorerApp/DataExplorerStateManager/DataExplorerStateManager";
 import { downloadRowsAsCSV } from "@/views/DataExplorerApp/downloadRowsAsCSV";
+import { OpenDatasetModal } from "@/views/DataExplorerApp/OpenDatasetModal/OpenDatasetModal";
 import { QueryForm } from "@/views/DataExplorerApp/QueryForm/QueryForm";
 import { SaveAsNewDatasetForm } from "@/views/DataExplorerApp/SaveAsNewDatasetForm/SaveAsNewDatasetForm";
+import { useDataExplorerURLSync } from "@/views/DataExplorerApp/useDataExplorerURLSync";
 import { useDataQuery } from "@/views/DataExplorerApp/useDataQuery";
 import { VisualizationContainer } from "@/views/DataExplorerApp/VisualizationContainer";
 import { VizSettingsForm } from "@/views/DataExplorerApp/VizSettingsForm/VizSettingsForm";
+import type { DataExplorerURLSearch } from "@/views/DataExplorerApp/DataExplorerURLState";
 
 const QUERY_FORM_WIDTH = 300;
 
-export function DataExplorerApp(): JSX.Element {
+type Props = {
+  urlSearch: DataExplorerURLSearch;
+  navigate: (options: {
+    search: DataExplorerURLSearch;
+    replace: boolean;
+  }) => void;
+};
+
+export function DataExplorerApp({ urlSearch, navigate }: Props): JSX.Element {
   const state = DataExplorerStateManager.useState();
   const dispatch = DataExplorerStateManager.useDispatch();
+
+  useDataExplorerURLSync({ urlSearch, navigate });
+
+  const [saveOverDataset, isSavingOver] = VirtualDatasetClient.useUpdate({
+    queryToInvalidate: DatasetClient.QueryKeys.getAll(),
+    onSuccess: () => {
+      notifySuccess("Dataset saved.");
+    },
+    onError: (error) => {
+      notifyError(`Failed to save dataset: ${error.message}`);
+    },
+  });
+
+  const [deleteDataset, isDeletingDataset] = DatasetClient.useFullDelete({
+    queryToInvalidate: DatasetClient.QueryKeys.getAll(),
+    onSuccess: () => {
+      dispatch.setOpenDataset(undefined);
+      dispatch.setRawSQL(undefined);
+      notifySuccess("Dataset deleted.");
+    },
+    onError: (error) => {
+      notifyError(`Failed to delete dataset: ${error.message}`);
+    },
+  });
+
   const workspace = useCurrentWorkspace();
   const [queryResults, isLoadingResults] = useDataQuery({
     query: state.query,
@@ -115,7 +156,10 @@ export function DataExplorerApp(): JSX.Element {
           style={styles.queryFormContainer}
         >
           <QueryForm />
-          <VizSettingsForm columns={queryResultColumns} />
+          <VizSettingsForm
+            columns={queryResultColumns}
+            data={queryResultData}
+          />
         </Box>
 
         <Stack flex={1} gap={0}>
@@ -127,7 +171,41 @@ export function DataExplorerApp(): JSX.Element {
             px="md"
             style={styles.toolbar}
           >
-            <Menu shadow="md" width={180}>
+            <Button
+              variant="subtle"
+              color="neutral"
+              leftSection={<IconRotateClockwise size={16} />}
+              size="compact-sm"
+              onClick={() => {
+                dispatch.resetState();
+                navigate({ search: {}, replace: true });
+              }}
+            >
+              Reset
+            </Button>
+            <Button
+              variant="outline"
+              color="neutral"
+              leftSection={<IconFolderOpen size={16} />}
+              size="compact-sm"
+              onClick={() => {
+                modals.open({
+                  title: "Open Dataset",
+                  size: "lg",
+                  children: (
+                    <OpenDatasetModal
+                      onOpen={(info, rawSQL) => {
+                        dispatch.setRawSQL(rawSQL);
+                        dispatch.setOpenDataset(info);
+                      }}
+                    />
+                  ),
+                });
+              }}
+            >
+              Open
+            </Button>
+            <Menu shadow="md" width={220}>
               <Menu.Target>
                 <Button
                   variant="outline"
@@ -139,6 +217,58 @@ export function DataExplorerApp(): JSX.Element {
                 </Button>
               </Menu.Target>
               <Menu.Dropdown>
+                {state.openDataset ?
+                  <>
+                    <Menu.Item
+                      disabled={!state.rawSQL || isSavingOver}
+                      onClick={() => {
+                        if (!state.rawSQL || !state.openDataset) {
+                          return;
+                        }
+                        saveOverDataset({
+                          id: state.openDataset.virtualDatasetId,
+                          data: { rawSQL: state.rawSQL },
+                        });
+                      }}
+                    >
+                      Save — {state.openDataset.name}
+                    </Menu.Item>
+                    <Menu.Item
+                      color="red"
+                      disabled={isDeletingDataset}
+                      onClick={() => {
+                        if (!state.openDataset) {
+                          return;
+                        }
+                        modals.openConfirmModal({
+                          title: "Delete dataset",
+                          children: (
+                            <Text size="sm">
+                              Permanently delete{" "}
+                              <strong>{state.openDataset.name}</strong>?
+                            </Text>
+                          ),
+                          labels: {
+                            confirm: "Delete",
+                            cancel: "Cancel",
+                          },
+                          confirmProps: { color: "red" },
+                          onConfirm: () => {
+                            if (!state.openDataset) {
+                              return;
+                            }
+                            deleteDataset({
+                              id: state.openDataset.datasetId,
+                            });
+                          },
+                        });
+                      }}
+                    >
+                      Delete — {state.openDataset.name}
+                    </Menu.Item>
+                    <Menu.Divider />
+                  </>
+                : null}
                 <Menu.Item
                   disabled={queryResultData.length === 0}
                   onClick={() => {

--- a/src/views/DataExplorerApp/DataExplorerStateManager/DataExplorerStateManager.tsx
+++ b/src/views/DataExplorerApp/DataExplorerStateManager/DataExplorerStateManager.tsx
@@ -8,6 +8,8 @@ import {
 } from "$/models/vizs/applyVizConfigFromQueryResult";
 import { VizConfigs } from "$/models/vizs/VizConfig/VizConfigs";
 import { createAppStateManager } from "@/lib/utils/state/createAppStateManager";
+import type { DatasetId } from "$/models/datasets/Dataset/Dataset.types";
+import type { VirtualDatasetId } from "$/models/datasets/VirtualDataset/VirtualDataset.types";
 import type { QueryAggregationType } from "$/models/queries/QueryAggregationType/QueryAggregationType.types";
 import type {
   QueryColumn,
@@ -24,7 +26,17 @@ import type {
   VizType,
 } from "$/models/vizs/VizConfig/VizConfig.types";
 
-type DataExplorerAppState = {
+/**
+ * Identifies the currently open saved dataset in the Data Explorer, if any.
+ * Stored in state so the toolbar can offer "Save Over" and "Delete" actions.
+ */
+export type OpenDatasetInfo = {
+  datasetId: DatasetId;
+  name: string;
+  virtualDatasetId: VirtualDatasetId;
+};
+
+export type DataExplorerAppState = {
   query: PartialStructuredQuery;
 
   /**
@@ -33,14 +45,18 @@ type DataExplorerAppState = {
    */
   rawSQL: string | undefined;
   vizConfig: VizConfig;
+
+  /** The currently open saved dataset, or `undefined` if none is open. */
+  openDataset: OpenDatasetInfo | undefined;
 };
 
-const initialState: DataExplorerAppState = {
+export const INITIAL_DATA_EXPLORER_STATE: DataExplorerAppState = {
   query: StructuredQuery.makeEmpty(),
   vizConfig: {
     vizType: "table",
   },
   rawSQL: undefined,
+  openDataset: undefined,
 };
 
 /**
@@ -51,7 +67,7 @@ const initialState: DataExplorerAppState = {
  */
 export const DataExplorerStateManager = createAppStateManager({
   name: "DataExplorer",
-  initialState,
+  initialState: INITIAL_DATA_EXPLORER_STATE,
   actions: {
     /** Set the data source for the query. */
     setDataSource: (
@@ -188,6 +204,22 @@ export const DataExplorerStateManager = createAppStateManager({
 
     setRawSQL: (state: DataExplorerAppState, rawSQL: string | undefined) => {
       return setValue(state, "rawSQL", rawSQL);
+    },
+
+    /**
+     * Set (or clear) the currently open saved dataset. Pass `undefined` to
+     * indicate no dataset is open.
+     */
+    setOpenDataset: (
+      state: DataExplorerAppState,
+      openDataset: OpenDatasetInfo | undefined,
+    ): DataExplorerAppState => {
+      return { ...state, openDataset };
+    },
+
+    /** Reset the Data Explorer to its initial (blank) state. */
+    resetState: (_state: DataExplorerAppState): DataExplorerAppState => {
+      return INITIAL_DATA_EXPLORER_STATE;
     },
   },
 });

--- a/src/views/DataExplorerApp/DataExplorerURLState.test.ts
+++ b/src/views/DataExplorerApp/DataExplorerURLState.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, it } from "vitest";
+import { StructuredQuery } from "$/models/queries/StructuredQuery/StructuredQuery";
+import {
+  isDefaultExplorerState,
+  parseURLSearch,
+  serializeStateToURL,
+} from "@/views/DataExplorerApp/DataExplorerURLState";
+import type {
+  DataExplorerAppState,
+  OpenDatasetInfo,
+} from "@/views/DataExplorerApp/DataExplorerStateManager/DataExplorerStateManager";
+import type { DatasetId } from "$/models/datasets/Dataset/Dataset.types";
+import type { VirtualDatasetId } from "$/models/datasets/VirtualDataset/VirtualDataset.types";
+import type { QueryColumn, QueryColumnId } from "$/models/queries/QueryColumn/QueryColumn.types";
+import type { QueryDataSource } from "$/models/queries/QueryDataSource/QueryDataSource.types";
+import type { DatasetColumnId } from "$/models/datasets/DatasetColumn/DatasetColumn.types";
+import type { PartialStructuredQuery } from "$/models/queries/StructuredQuery/StructuredQuery.types";
+import type { VizConfig } from "$/models/vizs/VizConfig/VizConfig.types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function _mockQueryColumn(
+  queryId: string,
+  baseId: string,
+  name: string,
+): QueryColumn {
+  return {
+    id: queryId as QueryColumnId,
+    aggregation: undefined,
+    baseColumn: { id: baseId as DatasetColumnId, name, dataType: "varchar" },
+  } as QueryColumn;
+}
+
+function _makeState(overrides: {
+  query?: PartialStructuredQuery;
+  rawSQL?: string;
+  vizConfig?: VizConfig;
+  openDataset?: OpenDatasetInfo;
+}): DataExplorerAppState {
+  return {
+    query: StructuredQuery.makeEmpty(),
+    vizConfig: { vizType: "table" },
+    rawSQL: undefined,
+    openDataset: undefined,
+    ...overrides,
+  };
+}
+
+function _makeQueryWithColumns(
+  dataSource: QueryDataSource,
+  columns: QueryColumn[],
+): PartialStructuredQuery {
+  return {
+    ...StructuredQuery.makeEmpty(),
+    dataSource,
+    queryColumns: columns,
+    aggregations: {},
+  } as unknown as PartialStructuredQuery;
+}
+
+const DS_ID = "2d527857-010e-498f-99af-a7a7c70cef5a";
+const MOCK_DS = { id: DS_ID } as QueryDataSource;
+
+// ---------------------------------------------------------------------------
+// parseURLSearch
+// ---------------------------------------------------------------------------
+
+describe("parseURLSearch", () => {
+  it("returns an empty object for an empty search", () => {
+    expect(parseURLSearch({})).toEqual({});
+  });
+
+  it("parses ds into dsId", () => {
+    const result = parseURLSearch({ ds: DS_ID });
+    expect(result.dsId).toBe(DS_ID);
+  });
+
+  it("parses cols into an array of column names", () => {
+    const result = parseURLSearch({ cols: "month,total_cases" });
+    expect(result.colNames).toEqual(["month", "total_cases"]);
+  });
+
+  it("filters empty strings out of cols", () => {
+    const result = parseURLSearch({ cols: "" });
+    expect(result.colNames).toBeUndefined();
+  });
+
+  it("parses agg into an aggregations record", () => {
+    const result = parseURLSearch({ agg: "total_cases:sum,month:group_by" });
+    expect(result.aggregations).toEqual({
+      total_cases: "sum",
+      month: "group_by",
+    });
+  });
+
+  it("ignores agg pairs with no colon", () => {
+    const result = parseURLSearch({ agg: "nocolon" });
+    expect(result.aggregations).toBeUndefined();
+  });
+
+  it("ignores agg pairs with an unrecognised aggregation type", () => {
+    const result = parseURLSearch({ agg: "col:not_a_real_agg" });
+    expect(result.aggregations).toBeUndefined();
+  });
+
+  it("parses orderBy and orderDir", () => {
+    const result = parseURLSearch({ orderBy: "month", orderDir: "asc" });
+    expect(result.orderByColName).toBe("month");
+    expect(result.orderDir).toBe("asc");
+  });
+
+  it("parses sql into rawSQL", () => {
+    const result = parseURLSearch({ sql: "SELECT 1" });
+    expect(result.rawSQL).toBe("SELECT 1");
+  });
+
+  it("parses ds, cols, and sql together (legacy combined URLs)", () => {
+    const result = parseURLSearch({
+      ds: DS_ID,
+      cols: "month,total_cases",
+      sql: "SELECT 1",
+    });
+    expect(result.dsId).toBe(DS_ID);
+    expect(result.colNames).toEqual(["month", "total_cases"]);
+    expect(result.rawSQL).toBe("SELECT 1");
+  });
+
+  it("parses a valid vc JSON string into vizConfig", () => {
+    const vc = JSON.stringify({ vizType: "bar", xAxisKey: "month" });
+    const result = parseURLSearch({ vc });
+    expect(result.vizConfig).toMatchObject({ vizType: "bar" });
+  });
+
+  it("silently ignores a malformed vc JSON string", () => {
+    const result = parseURLSearch({ vc: "not-valid-json{{" });
+    expect(result.vizConfig).toBeUndefined();
+  });
+
+  it("parses a valid od JSON string into openDataset", () => {
+    const od = JSON.stringify({
+      did: "did-1",
+      name: "My Dataset",
+      vid: "vid-1",
+    });
+    const result = parseURLSearch({ od });
+    expect(result.openDataset).toEqual({
+      datasetId: "did-1",
+      name: "My Dataset",
+      virtualDatasetId: "vid-1",
+    });
+  });
+
+  it("silently ignores a malformed od JSON string", () => {
+    const result = parseURLSearch({ od: "{bad-json" });
+    expect(result.openDataset).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// serializeStateToURL
+// ---------------------------------------------------------------------------
+
+describe("serializeStateToURL", () => {
+  it("produces an empty param object for the initial empty state", () => {
+    const result = serializeStateToURL(_makeState({}));
+    expect(result).toEqual({});
+  });
+
+  it("serializes the data source id into ds", () => {
+    const result = serializeStateToURL(
+      _makeState({
+        query: _makeQueryWithColumns(MOCK_DS, []),
+      }),
+    );
+    expect(result.ds).toBe(DS_ID);
+  });
+
+  it("serializes column names as a comma-separated cols string", () => {
+    const col1 = _mockQueryColumn("q1", "b1", "month");
+    const col2 = _mockQueryColumn("q2", "b2", "total_cases");
+    const result = serializeStateToURL(
+      _makeState({
+        query: _makeQueryWithColumns(MOCK_DS, [col1, col2]),
+      }),
+    );
+    expect(result.cols).toBe("month,total_cases");
+  });
+
+  it("omits cols when no columns are selected", () => {
+    const result = serializeStateToURL(
+      _makeState({ query: _makeQueryWithColumns(MOCK_DS, []) }),
+    );
+    expect(result.cols).toBeUndefined();
+  });
+
+  it("omits agg when all aggregations are none", () => {
+    const col = _mockQueryColumn("q1", "b1", "month");
+    const query = {
+      ..._makeQueryWithColumns(MOCK_DS, [col]),
+      aggregations: { ["q1" as QueryColumnId]: "none" as const },
+    } as unknown as PartialStructuredQuery;
+    const result = serializeStateToURL(_makeState({ query }));
+    expect(result.agg).toBeUndefined();
+  });
+
+  it("includes agg only for non-none aggregations", () => {
+    const col = _mockQueryColumn("q1", "b1", "total_cases");
+    const query = {
+      ..._makeQueryWithColumns(MOCK_DS, [col]),
+      aggregations: { ["q1" as QueryColumnId]: "sum" as const },
+    } as unknown as PartialStructuredQuery;
+    const result = serializeStateToURL(_makeState({ query }));
+    expect(result.agg).toBe("total_cases:sum");
+  });
+
+  it("serializes rawSQL into the sql param", () => {
+    const result = serializeStateToURL(
+      _makeState({ rawSQL: "SELECT * FROM t" }),
+    );
+    expect(result.sql).toBe("SELECT * FROM t");
+  });
+
+  it("includes vc when vizType is not the default table", () => {
+    const vizConfig: VizConfig = {
+      vizType: "line",
+      xAxisKey: "month",
+      yAxisKey: "total_cases",
+      withLegend: false,
+      curveType: "monotone",
+    };
+    const result = serializeStateToURL(_makeState({ vizConfig }));
+    expect(result.vc).toBeDefined();
+    expect(JSON.parse(result.vc!)).toMatchObject({
+      vizType: "line",
+      xAxisKey: "month",
+    });
+  });
+
+  it("omits vc when vizType is the default table", () => {
+    const result = serializeStateToURL(
+      _makeState({ vizConfig: { vizType: "table" } }),
+    );
+    expect(result.vc).toBeUndefined();
+  });
+
+  it("omits ds, cols, agg, and order when rawSQL is set", () => {
+    const col = _mockQueryColumn("q1", "b1", "month");
+    const query = {
+      ..._makeQueryWithColumns(MOCK_DS, [col]),
+      aggregations: { ["q1" as QueryColumnId]: "sum" as const },
+      orderByColumn: "q1" as QueryColumnId,
+      orderByDirection: "desc" as const,
+    } as unknown as PartialStructuredQuery;
+    const result = serializeStateToURL(
+      _makeState({ query, rawSQL: "SELECT 1" }),
+    );
+    expect(result.sql).toBe("SELECT 1");
+    expect(result.ds).toBeUndefined();
+    expect(result.cols).toBeUndefined();
+    expect(result.agg).toBeUndefined();
+    expect(result.orderBy).toBeUndefined();
+    expect(result.orderDir).toBeUndefined();
+  });
+
+  it("serializes openDataset into the od param", () => {
+    const openDataset: OpenDatasetInfo = {
+      datasetId: "did-1" as DatasetId,
+      name: "My Dataset",
+      virtualDatasetId: "vid-1" as VirtualDatasetId,
+    };
+    const result = serializeStateToURL(_makeState({ openDataset }));
+    expect(result.od).toBeDefined();
+    const parsed = JSON.parse(result.od!);
+    expect(parsed).toEqual({ did: "did-1", name: "My Dataset", vid: "vid-1" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isDefaultExplorerState
+// ---------------------------------------------------------------------------
+
+describe("isDefaultExplorerState", () => {
+  it("returns true for the initial blank state", () => {
+    expect(isDefaultExplorerState(_makeState({}))).toBe(true);
+  });
+
+  it("returns false when a data source is set", () => {
+    expect(
+      isDefaultExplorerState(
+        _makeState({ query: _makeQueryWithColumns(MOCK_DS, []) }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when queryColumns are non-empty", () => {
+    const col = _mockQueryColumn("q1", "b1", "month");
+    expect(
+      isDefaultExplorerState(
+        _makeState({
+          query: _makeQueryWithColumns(MOCK_DS, [col]),
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when rawSQL is set", () => {
+    expect(
+      isDefaultExplorerState(_makeState({ rawSQL: "SELECT 1" })),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip: serializeStateToURL → parseURLSearch
+// ---------------------------------------------------------------------------
+
+describe("round-trip: serialize then parse", () => {
+  it("preserves ds and cols through a serialize/parse cycle", () => {
+    const col1 = _mockQueryColumn("q1", "b1", "month");
+    const col2 = _mockQueryColumn("q2", "b2", "total_cases");
+    const state = _makeState({
+      query: _makeQueryWithColumns(MOCK_DS, [col1, col2]),
+    });
+
+    const parsed = parseURLSearch(serializeStateToURL(state));
+
+    expect(parsed.dsId).toBe(DS_ID);
+    expect(parsed.colNames).toEqual(["month", "total_cases"]);
+  });
+
+  it("preserves rawSQL through a serialize/parse cycle", () => {
+    const sql = "SELECT month, total_cases FROM t";
+    const parsed = parseURLSearch(
+      serializeStateToURL(_makeState({ rawSQL: sql })),
+    );
+    expect(parsed.rawSQL).toBe(sql);
+  });
+
+  it("does not put structured keys in URL when rawSQL is set", () => {
+    const col1 = _mockQueryColumn("q1", "b1", "month");
+    const state = _makeState({
+      query: _makeQueryWithColumns(MOCK_DS, [col1]),
+      rawSQL: "SELECT * FROM \"dummy\"",
+    });
+    const parsed = parseURLSearch(serializeStateToURL(state));
+    expect(parsed.rawSQL).toBe("SELECT * FROM \"dummy\"");
+    expect(parsed.dsId).toBeUndefined();
+    expect(parsed.colNames).toBeUndefined();
+  });
+
+  it("preserves vizConfig type through a serialize/parse cycle", () => {
+    const vizConfig: VizConfig = {
+      vizType: "bar",
+      xAxisKey: "month",
+      yAxisKey: "total_cases",
+      withLegend: true,
+    };
+    const parsed = parseURLSearch(
+      serializeStateToURL(_makeState({ vizConfig })),
+    );
+    expect(parsed.vizConfig?.vizType).toBe("bar");
+  });
+});

--- a/src/views/DataExplorerApp/DataExplorerURLState.ts
+++ b/src/views/DataExplorerApp/DataExplorerURLState.ts
@@ -1,0 +1,236 @@
+import { z } from "zod";
+import type { QueryAggregationType } from "$/models/queries/QueryAggregationType/QueryAggregationType.types";
+import type { OrderByDirection } from "$/models/queries/StructuredQuery/StructuredQuery.types";
+import type { VizConfig } from "$/models/vizs/VizConfig/VizConfig.types";
+import type {
+  DataExplorerAppState,
+  OpenDatasetInfo,
+} from "@/views/DataExplorerApp/DataExplorerStateManager/DataExplorerStateManager";
+
+/**
+ * Zod schema for the Data Explorer URL search params.
+ *
+ * We persist a minimal set of identifiers rather than serialising full
+ * model objects, keeping URLs short and human-readable:
+ *
+ *   ?ds=<dataSourceId>
+ *   &cols=<colName1>,<colName2>
+ *   &agg=<colName>:<aggregationType>,...
+ *   &orderBy=<colName>&orderDir=asc|desc
+ *   &sql=<rawSQL>
+ *   &vc=<JSON-stringified VizConfig> (omitted when viz is the default table)
+ *
+ * When `sql` is present it is the authoritative query: `ds`, `cols`, `agg`,
+ * and `orderBy`/`orderDir` are not written (and are ignored on hydrate) so a
+ * leftover Manual Query cannot conflict with AI / edited SQL.
+ */
+export const DataExplorerSearchSchema = z.object({
+  ds: z.string().optional(),
+  cols: z.string().optional(),
+  agg: z.string().optional(),
+  orderBy: z.string().optional(),
+  orderDir: z.enum(["asc", "desc"] as const).optional(),
+  sql: z.string().optional(),
+  vc: z.string().optional(),
+
+  /** Compact JSON of `{ did, name, vid }` identifying the open dataset. */
+  od: z.string().optional(),
+});
+
+export type DataExplorerURLSearch = z.infer<typeof DataExplorerSearchSchema>;
+
+export type ParsedURLState = {
+  dsId?: string;
+  colNames?: readonly string[];
+  aggregations?: Readonly<Record<string, QueryAggregationType>>;
+  orderByColName?: string;
+  orderDir?: OrderByDirection;
+  rawSQL?: string;
+  vizConfig?: VizConfig;
+  openDataset?: OpenDatasetInfo;
+};
+
+const VALID_AGGREGATION_VALUES = new Set([
+  "sum",
+  "avg",
+  "count",
+  "max",
+  "min",
+  "group_by",
+  "none",
+]);
+
+function _isValidAgg(value: string): value is QueryAggregationType {
+  return VALID_AGGREGATION_VALUES.has(value);
+}
+
+/**
+ * Parses the raw URL search params into typed, structured state that the
+ * Data Explorer can use to restore its session.
+ */
+export function parseURLSearch(
+  search: DataExplorerURLSearch,
+): ParsedURLState {
+  const result: ParsedURLState = {};
+
+  if (search.ds) {
+    result.dsId = search.ds;
+  }
+
+  if (search.cols) {
+    result.colNames = search.cols.split(",").filter(Boolean);
+  }
+
+  if (search.agg) {
+    const agg: Record<string, QueryAggregationType> = {};
+    search.agg.split(",").forEach((pair) => {
+      const idx = pair.indexOf(":");
+      if (idx === -1) {
+        return;
+      }
+      const name = pair.slice(0, idx);
+      const type = pair.slice(idx + 1);
+      if (name && _isValidAgg(type)) {
+        agg[name] = type;
+      }
+    });
+    if (Object.keys(agg).length > 0) {
+      result.aggregations = agg;
+    }
+  }
+
+  if (search.orderBy) {
+    result.orderByColName = search.orderBy;
+  }
+
+  if (search.orderDir) {
+    result.orderDir = search.orderDir;
+  }
+
+  if (search.sql) {
+    result.rawSQL = search.sql;
+  }
+
+  if (search.vc) {
+    try {
+      result.vizConfig = JSON.parse(search.vc) as VizConfig;
+    } catch {
+      // Ignore malformed JSON — the viz will fall back to defaults.
+    }
+  }
+
+  if (search.od) {
+    try {
+      const raw = JSON.parse(search.od) as {
+        did: string;
+        name: string;
+        vid: string;
+      };
+      if (raw.did && raw.name && raw.vid) {
+        result.openDataset = {
+          datasetId: raw.did as OpenDatasetInfo["datasetId"],
+          name: raw.name,
+          virtualDatasetId: raw.vid as OpenDatasetInfo["virtualDatasetId"],
+        };
+      }
+    } catch {
+      // Ignore malformed JSON.
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Serialises the current Data Explorer state into the compact URL search
+ * param format. Only non-default values are included.
+ */
+export function serializeStateToURL(
+  state: DataExplorerAppState,
+): DataExplorerURLSearch {
+  const { query, rawSQL, vizConfig } = state;
+  const params: DataExplorerURLSearch = {};
+
+  // Raw SQL drives execution in `useDataQuery`; structured fields are ignored
+  // when `rawSQL` is set. Omit them from the URL so refresh never pairs a
+  // stale `ds` from Manual Query with SQL that references other table names.
+  if (!rawSQL) {
+    if (query.dataSource) {
+      params.ds = query.dataSource.id;
+    }
+
+    if (query.queryColumns.length > 0) {
+      params.cols = query.queryColumns
+        .map((col) => {
+          return col.baseColumn.name;
+        })
+        .join(",");
+
+      const nonDefaultAggs = query.queryColumns.filter((col) => {
+        const agg = query.aggregations[col.id];
+        return agg !== undefined && agg !== "none";
+      });
+
+      if (nonDefaultAggs.length > 0) {
+        params.agg = nonDefaultAggs
+          .map((col) => {
+            return `${col.baseColumn.name}:${query.aggregations[col.id]}`;
+          })
+          .join(",");
+      }
+    }
+
+    if (query.orderByColumn) {
+      const orderCol = query.queryColumns.find((col) => {
+        return col.id === query.orderByColumn;
+      });
+      if (orderCol) {
+        params.orderBy = orderCol.baseColumn.name;
+        if (query.orderByDirection) {
+          params.orderDir = query.orderByDirection;
+        }
+      }
+    }
+  }
+
+  if (rawSQL) {
+    params.sql = rawSQL;
+  }
+
+  // Omit `vc` when the viz is the same as the initial Data Explorer default
+  // (`table` only). Otherwise Reset + URL sync would immediately put
+  // `?vc={"vizType":"table"}` back after `navigate({ search: {} })`, and the
+  // query string could never clear in one action.
+  try {
+    if (vizConfig.vizType !== "table") {
+      params.vc = JSON.stringify(vizConfig);
+    }
+  } catch {
+    // Ignore — viz config will fall back to defaults on next load.
+  }
+
+  if (state.openDataset) {
+    const { datasetId, name, virtualDatasetId } = state.openDataset;
+    params.od = JSON.stringify({
+      did: datasetId,
+      name,
+      vid: virtualDatasetId,
+    });
+  }
+
+  return params;
+}
+
+/**
+ * Returns `true` when the Data Explorer state has not yet been modified from
+ * its initial blank state (no data source, no columns, no raw SQL).
+ */
+export function isDefaultExplorerState(
+  state: DataExplorerAppState,
+): boolean {
+  return (
+    state.query.dataSource === undefined &&
+    state.query.queryColumns.length === 0 &&
+    state.rawSQL === undefined
+  );
+}

--- a/src/views/DataExplorerApp/OpenDatasetModal/OpenDatasetModal.tsx
+++ b/src/views/DataExplorerApp/OpenDatasetModal/OpenDatasetModal.tsx
@@ -1,0 +1,180 @@
+import {
+  ActionIcon,
+  Button,
+  Group,
+  Stack,
+  Table,
+  Text,
+  TextInput,
+} from "@mantine/core";
+import { useDebouncedValue } from "@mantine/hooks";
+import { modals } from "@mantine/modals";
+import { IconSearch, IconTrash } from "@tabler/icons-react";
+import { where } from "@utils/filters/where/where";
+import { notifyError, notifySuccess } from "@ui/index";
+import { useState } from "react";
+import { DatasetClient } from "@/clients/datasets/DatasetClient";
+import { VirtualDatasetClient } from "@/clients/datasets/VirtualDatasetClient";
+import { useCurrentWorkspace } from "@/hooks/workspaces/useCurrentWorkspace";
+import { useMutation } from "@hooks/useMutation/useMutation";
+import type { Dataset } from "$/models/datasets/Dataset/Dataset.types";
+import type { VirtualDatasetRead } from "$/models/datasets/VirtualDataset/VirtualDataset.types";
+import type { OpenDatasetInfo } from "@/views/DataExplorerApp/DataExplorerStateManager/DataExplorerStateManager";
+
+type Props = {
+  onOpen: (info: OpenDatasetInfo, rawSQL: string) => void;
+};
+
+/**
+ * Modal body for browsing and opening saved (virtual) datasets in the
+ * Data Explorer. Only datasets created via AI query ("virtual" source type)
+ * have a raw SQL query that can be loaded back into the explorer.
+ */
+export function OpenDatasetModal({ onOpen }: Props): JSX.Element {
+  const workspace = useCurrentWorkspace();
+  const [search, setSearch] = useState("");
+  const [debouncedSearch] = useDebouncedValue(search, 200);
+
+  const [datasets, isLoadingDatasets] = DatasetClient.useGetAll({
+    ...where("workspace_id", "eq", workspace.id),
+    useQueryOptions: { enabled: true },
+  });
+
+  const virtualDatasets = (datasets ?? []).filter((d) => {
+    return d.sourceType === "virtual";
+  });
+
+  const filtered = virtualDatasets.filter((d) => {
+    if (!debouncedSearch) {
+      return true;
+    }
+    return d.name.toLowerCase().includes(debouncedSearch.toLowerCase());
+  });
+
+  const [deleteDataset, isDeletingDataset] = DatasetClient.useFullDelete({
+    queryToInvalidate: DatasetClient.QueryKeys.getAll(),
+    onSuccess: () => {
+      notifySuccess("Dataset deleted.");
+    },
+    onError: (error) => {
+      notifyError(`Failed to delete dataset: ${error.message}`);
+    },
+  });
+
+  const [loadVirtualDataset, isLoadingVirtualDataset] = useMutation({
+    mutationFn: async (dataset: Dataset) => {
+      const virtualDataset = await VirtualDatasetClient.getOne(
+        where("dataset_id", "eq", dataset.id),
+      );
+      if (!virtualDataset) {
+        throw new Error("Could not load the dataset's SQL query.");
+      }
+      return { dataset, virtualDataset };
+    },
+    onSuccess: ({
+      dataset,
+      virtualDataset,
+    }: {
+      dataset: Dataset;
+      virtualDataset: VirtualDatasetRead;
+    }) => {
+      onOpen(
+        {
+          datasetId: dataset.id,
+          name: dataset.name,
+          virtualDatasetId: virtualDataset.id,
+        },
+        virtualDataset.rawSQL,
+      );
+      modals.closeAll();
+    },
+    onError: (error: Error) => {
+      notifyError(error.message);
+    },
+  });
+
+  const onDeleteClick = (dataset: Dataset) => {
+    modals.openConfirmModal({
+      title: "Delete dataset",
+      children: (
+        <Text size="sm">
+          Are you sure you want to permanently delete{" "}
+          <strong>{dataset.name}</strong>? This cannot be undone.
+        </Text>
+      ),
+      labels: { confirm: "Delete", cancel: "Cancel" },
+      confirmProps: { color: "red" },
+      onConfirm: () => {
+        deleteDataset({ id: dataset.id });
+      },
+    });
+  };
+
+  const isBusy = isLoadingVirtualDataset || isDeletingDataset;
+
+  return (
+    <Stack gap="sm">
+      <TextInput
+        placeholder="Search datasets..."
+        leftSection={<IconSearch size={14} />}
+        value={search}
+        onChange={(e) => {
+          setSearch(e.currentTarget.value);
+        }}
+      />
+
+      {isLoadingDatasets ?
+        <Text c="dimmed" size="sm">
+          Loading datasets…
+        </Text>
+      : filtered.length === 0 ?
+        <Text c="dimmed" size="sm">
+          No saved datasets found.
+        </Text>
+      : <Table highlightOnHover>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Name</Table.Th>
+              <Table.Th w={100} />
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {filtered.map((dataset) => {
+              return (
+                <Table.Tr key={dataset.id}>
+                  <Table.Td>{dataset.name}</Table.Td>
+                  <Table.Td>
+                    <Group gap="xs" justify="flex-end">
+                      <Button
+                        size="compact-xs"
+                        variant="light"
+                        disabled={isBusy}
+                        onClick={() => {
+                          loadVirtualDataset(dataset);
+                        }}
+                      >
+                        Open
+                      </Button>
+                      <ActionIcon
+                        size="sm"
+                        variant="subtle"
+                        color="red"
+                        disabled={isBusy}
+                        aria-label={`Delete ${dataset.name}`}
+                        onClick={() => {
+                          onDeleteClick(dataset);
+                        }}
+                      >
+                        <IconTrash size={14} />
+                      </ActionIcon>
+                    </Group>
+                  </Table.Td>
+                </Table.Tr>
+              );
+            })}
+          </Table.Tbody>
+        </Table>
+      }
+    </Stack>
+  );
+}

--- a/src/views/DataExplorerApp/QueryColumnMultiSelect/QueryColumnMultiSelect.tsx
+++ b/src/views/DataExplorerApp/QueryColumnMultiSelect/QueryColumnMultiSelect.tsx
@@ -15,6 +15,7 @@ import { matchSorter } from "match-sorter";
 import { useEffect, useMemo } from "react";
 import { DatasetColumnClient } from "@/clients/datasets/DatasetColumnClient";
 import { EntityFieldConfigClient } from "@/clients/entities/EntityFieldConfigClient";
+import { remapColumnsByBaseId } from "@/views/DataExplorerApp/QueryColumnMultiSelect/remapColumnsByBaseId";
 import type {
   ComboboxItem,
   ComboboxParsedItem,
@@ -133,16 +134,18 @@ export function QueryColumnMultiSelect({
     };
   }, [queryColumns]);
 
-  // If the available columns change (e.g. if the `dataSourceId` changed)
-  // we should drop any selections that are no longer valid.
+  // When available columns change (e.g. data source changed, or columns
+  // were restored from URL with different synthetic UUIDs), remap the
+  // current selection to the canonical instances from the available set.
   useEffect(() => {
-    const prunedSelectedColumns = currentSelectedColumns.filter((col) => {
-      return queryColumnLookup.has(col.id);
+    const remapped = remapColumnsByBaseId({
+      selectedColumns: currentSelectedColumns,
+      availableColumns: queryColumns,
     });
-    if (prunedSelectedColumns.length !== currentSelectedColumns.length) {
-      setCurrentSelectedColumns(prunedSelectedColumns);
+    if (remapped !== undefined) {
+      setCurrentSelectedColumns(remapped);
     }
-  }, [queryColumnLookup, currentSelectedColumns, setCurrentSelectedColumns]);
+  }, [queryColumns, currentSelectedColumns, setCurrentSelectedColumns]);
 
   const selectedColumnIds = useMemo(() => {
     return currentSelectedColumns.map(prop("id"));

--- a/src/views/DataExplorerApp/QueryColumnMultiSelect/remapColumnsByBaseId.test.ts
+++ b/src/views/DataExplorerApp/QueryColumnMultiSelect/remapColumnsByBaseId.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import { remapColumnsByBaseId } from "@/views/DataExplorerApp/QueryColumnMultiSelect/remapColumnsByBaseId";
+import type {
+  QueryColumn,
+  QueryColumnId,
+} from "$/models/queries/QueryColumn/QueryColumn.types";
+import type { DatasetColumnId } from "$/models/datasets/DatasetColumn/DatasetColumn.types";
+
+/**
+ * Builds a minimal `QueryColumn` fixture.
+ *
+ * @param queryId - Synthetic `QueryColumn.id` (UUID generated at call-site).
+ * @param baseId - Stable `baseColumn.id` (database primary key).
+ * @param name - Column display name.
+ */
+function _mockCol(
+  queryId: string,
+  baseId: string,
+  name: string,
+): QueryColumn {
+  return {
+    id: queryId as QueryColumnId,
+    aggregation: undefined,
+    baseColumn: {
+      id: baseId as DatasetColumnId,
+      name,
+      dataType: "varchar",
+    },
+  } as QueryColumn;
+}
+
+describe("remapColumnsByBaseId", () => {
+  describe("returns undefined (no change needed)", () => {
+    it("returns undefined for an empty selection", () => {
+      const available = [_mockCol("q1", "b1", "month")];
+      expect(
+        remapColumnsByBaseId({
+          selectedColumns: [],
+          availableColumns: available,
+        }),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined when selected columns already match available", () => {
+      const col = _mockCol("q1", "b1", "month");
+      expect(
+        remapColumnsByBaseId({
+          selectedColumns: [col],
+          availableColumns: [col],
+        }),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined when multiple selected columns all match", () => {
+      const col1 = _mockCol("q1", "b1", "month");
+      const col2 = _mockCol("q2", "b2", "total_cases");
+      expect(
+        remapColumnsByBaseId({
+          selectedColumns: [col1, col2],
+          availableColumns: [col1, col2],
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("URL hydration — same baseColumn.id, different QueryColumn.id", () => {
+    it("remaps a single column to the canonical available instance", () => {
+      // Simulates URL hydration: the URL sync hook creates a QueryColumn
+      // with a different synthetic UUID than the one in the MultiSelect's
+      // internal lookup. Both refer to the same underlying DB column.
+      const hydrated = _mockCol("hydrated-uuid", "base-db-id", "month");
+      const canonical = _mockCol("canonical-uuid", "base-db-id", "month");
+
+      const result = remapColumnsByBaseId({
+        selectedColumns: [hydrated],
+        availableColumns: [canonical],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result![0]!.id).toBe("canonical-uuid");
+      expect(result![0]!.baseColumn.id).toBe("base-db-id");
+    });
+
+    it("remaps multiple columns, preserving order", () => {
+      const hydratedMonth = _mockCol("h-month", "b-month", "month");
+      const hydratedCases = _mockCol("h-cases", "b-cases", "total_cases");
+      const canonMonth = _mockCol("c-month", "b-month", "month");
+      const canonCases = _mockCol("c-cases", "b-cases", "total_cases");
+
+      const result = remapColumnsByBaseId({
+        selectedColumns: [hydratedMonth, hydratedCases],
+        availableColumns: [canonMonth, canonCases],
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result![0]!.id).toBe("c-month");
+      expect(result![1]!.id).toBe("c-cases");
+    });
+  });
+
+  describe("data source change — column no longer available", () => {
+    it("drops a column that is not in the new available set", () => {
+      const oldCol = _mockCol("q-old", "b-old", "old_metric");
+      const newCol = _mockCol("q-new", "b-new", "new_metric");
+
+      const result = remapColumnsByBaseId({
+        selectedColumns: [oldCol],
+        availableColumns: [newCol],
+      });
+
+      expect(result).toHaveLength(0);
+    });
+
+    it("drops stale columns but keeps valid ones", () => {
+      const stale = _mockCol("q-stale", "b-stale", "removed_col");
+      const valid = _mockCol("q-valid", "b-valid", "kept_col");
+      const canonValid = _mockCol("c-valid", "b-valid", "kept_col");
+
+      const result = remapColumnsByBaseId({
+        selectedColumns: [stale, valid],
+        availableColumns: [canonValid],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result![0]!.id).toBe("c-valid");
+    });
+
+    it("returns an empty array (not undefined) when all columns are dropped", () => {
+      const stale = _mockCol("q-stale", "b-stale", "gone");
+
+      const result = remapColumnsByBaseId({
+        selectedColumns: [stale],
+        availableColumns: [],
+      });
+
+      // Must be [] not undefined — caller must clear the selection.
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("empty available set", () => {
+    it("returns empty array when available is empty and selection is non-empty", () => {
+      const col = _mockCol("q1", "b1", "month");
+
+      const result = remapColumnsByBaseId({
+        selectedColumns: [col],
+        availableColumns: [],
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns undefined when both selection and available are empty", () => {
+      expect(
+        remapColumnsByBaseId({
+          selectedColumns: [],
+          availableColumns: [],
+        }),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/src/views/DataExplorerApp/QueryColumnMultiSelect/remapColumnsByBaseId.ts
+++ b/src/views/DataExplorerApp/QueryColumnMultiSelect/remapColumnsByBaseId.ts
@@ -1,0 +1,52 @@
+import { isNonNullish } from "@utils/guards/isNonNullish/isNonNullish";
+import type { QueryColumn } from "$/models/queries/QueryColumn/QueryColumn.types";
+
+/**
+ * Re-maps a selection of `QueryColumn`s to canonical instances from the
+ * available set, matching by `baseColumn.id` (the stable database primary
+ * key) rather than `QueryColumn.id` (a synthetic UUID generated per call).
+ *
+ * Returns the remapped array when anything changed; returns `undefined`
+ * when the selection is already consistent so callers can skip
+ * unnecessary state updates.
+ *
+ * Handles two cases:
+ * - Column no longer in available set (data source changed) — dropped.
+ * - Column present but created with a different synthetic UUID (e.g.
+ *   restored from URL) — remapped to the canonical available instance.
+ *
+ * @param options.selectedColumns - The currently selected columns.
+ * @param options.availableColumns - All columns for the current source.
+ * @returns Remapped array, or `undefined` if no change was needed.
+ */
+export function remapColumnsByBaseId(options: {
+  selectedColumns: readonly QueryColumn[];
+  availableColumns: readonly QueryColumn[];
+}): readonly QueryColumn[] | undefined {
+  const { selectedColumns, availableColumns } = options;
+
+  // Index available columns by their stable DB id for O(1) lookup.
+  const availableByBaseId = new Map(
+    availableColumns.map((col) => {
+      return [col.baseColumn.id, col] as const;
+    }),
+  );
+
+  // Re-map each selected column to the matching available instance.
+  // Columns whose base column is no longer in the available set are
+  // dropped by `filter(isNonNullish)`.
+  const remappedColumns = selectedColumns
+    .map((col) => {
+      return availableByBaseId.get(col.baseColumn.id);
+    })
+    .filter(isNonNullish);
+
+  const isChanged =
+    remappedColumns.length !== selectedColumns.length ||
+    remappedColumns.some((col, index) => {
+      const prior = selectedColumns[index];
+      return prior === undefined || col.id !== prior.id;
+    });
+
+  return isChanged ? remappedColumns : undefined;
+}

--- a/src/views/DataExplorerApp/QueryForm/ManualQueryForm.tsx
+++ b/src/views/DataExplorerApp/QueryForm/ManualQueryForm.tsx
@@ -6,7 +6,7 @@ import { prop } from "@utils/objects/hofs/prop/prop";
 import { QueryColumns } from "$/models/queries/QueryColumn/QueryColumns";
 import { AggregationSelect } from "@/views/DataExplorerApp/AggregationSelect";
 import { DataExplorerStateManager } from "@/views/DataExplorerApp/DataExplorerStateManager/DataExplorerStateManager";
-import { QueryColumnMultiSelect } from "@/views/DataExplorerApp/QueryColumnMultiSelect";
+import { QueryColumnMultiSelect } from "@/views/DataExplorerApp/QueryColumnMultiSelect/QueryColumnMultiSelect";
 import { QueryDataSourceSelect } from "@/views/DataExplorerApp/QueryDataSourceSelect";
 import type { SelectData } from "@ui/inputs/Select/Select";
 import type { QueryAggregationType } from "$/models/queries/QueryAggregationType/QueryAggregationType.types";

--- a/src/views/DataExplorerApp/VisualizationContainer.tsx
+++ b/src/views/DataExplorerApp/VisualizationContainer.tsx
@@ -1,4 +1,4 @@
-import { Flex, List, Text } from "@mantine/core";
+import { Box, Flex, List, Text } from "@mantine/core";
 import { prop } from "@utils/objects/hofs/prop/prop";
 import { objectValues } from "@utils/objects/objectValues";
 import { UnknownDataFrame } from "@utils/types/common.types";
@@ -14,9 +14,7 @@ import { LineChart } from "@/lib/ui/viz/LineChart";
 import { PieChart } from "@/lib/ui/viz/PieChart";
 import { RadarChart } from "@/lib/ui/viz/RadarChart";
 import { ScatterChart } from "@/lib/ui/viz/ScatterChart";
-import {
-  DataExplorerStateManager,
-} from "@/views/DataExplorerApp/DataExplorerStateManager/DataExplorerStateManager";
+import { DataExplorerStateManager } from "@/views/DataExplorerApp/DataExplorerStateManager/DataExplorerStateManager";
 import { DangerText } from "@/lib/ui/text/DangerText";
 import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types";
 
@@ -139,13 +137,16 @@ export function VisualizationContainer({
       } = BarChartConfigSchema.safeParse(config);
       if (success) {
         return (
-          <BarChart
-            data={data}
-            height={700}
-            dateColumns={dateColumns}
-            withLegend={config.withLegend}
-            {...validConfig}
-          />
+          <Box w="100%">
+            <BarChart
+              data={data}
+              height={700}
+              dateColumns={dateColumns}
+              withLegend={config.withLegend}
+              color={config.color}
+              {...validConfig}
+            />
+          </Box>
         );
       }
 
@@ -189,14 +190,17 @@ export function VisualizationContainer({
 
       if (success) {
         return (
-          <LineChart
-            data={data}
-            height={700}
-            dateColumns={dateColumns}
-            withLegend={config.withLegend}
-            curveType={config.curveType}
-            {...validConfig}
-          />
+          <Box w="100%">
+            <LineChart
+              data={data}
+              height={700}
+              dateColumns={dateColumns}
+              withLegend={config.withLegend}
+              curveType={config.curveType}
+              color={config.color}
+              {...validConfig}
+            />
+          </Box>
         );
       }
       return <DangerText>{prettifyError(error)}</DangerText>;
@@ -210,14 +214,17 @@ export function VisualizationContainer({
 
       if (success) {
         return (
-          <AreaChart
-            data={data}
-            height={700}
-            dateColumns={dateColumns}
-            withLegend={config.withLegend}
-            curveType={config.curveType}
-            {...validConfig}
-          />
+          <Box w="100%">
+            <AreaChart
+              data={data}
+              height={700}
+              dateColumns={dateColumns}
+              withLegend={config.withLegend}
+              curveType={config.curveType}
+              color={config.color}
+              {...validConfig}
+            />
+          </Box>
         );
       }
       return <DangerText>{prettifyError(error)}</DangerText>;
@@ -250,6 +257,7 @@ export function VisualizationContainer({
             isDonut={config.isDonut}
             withLabels={config.withLabels}
             labelsType={config.labelsType}
+            seriesColors={config.seriesColors}
           />
         );
       }
@@ -268,6 +276,7 @@ export function VisualizationContainer({
             data={data}
             nameKey={validConfig.nameKey}
             valueKey={validConfig.valueKey}
+            seriesColors={config.seriesColors}
           />
         );
       }
@@ -286,6 +295,7 @@ export function VisualizationContainer({
             data={data}
             nameKey={validConfig.nameKey}
             valueKey={validConfig.valueKey}
+            color={config.color}
           />
         );
       }

--- a/src/views/DataExplorerApp/VisualizationContainer.tsx
+++ b/src/views/DataExplorerApp/VisualizationContainer.tsx
@@ -5,12 +5,19 @@ import { UnknownDataFrame } from "@utils/types/common.types";
 import { match } from "ts-pattern";
 import { flattenError, object, prettifyError, string } from "zod";
 import { Callout } from "@/lib/ui/Callout";
-import { DangerText } from "@/lib/ui/text/DangerText";
+import { AreaChart } from "@/lib/ui/viz/AreaChart";
 import { BarChart } from "@/lib/ui/viz/BarChart";
+import { BubbleChart } from "@/lib/ui/viz/BubbleChart";
 import { DataGrid } from "@/lib/ui/viz/DataGrid";
+import { FunnelChart } from "@/lib/ui/viz/FunnelChart";
 import { LineChart } from "@/lib/ui/viz/LineChart";
+import { PieChart } from "@/lib/ui/viz/PieChart";
+import { RadarChart } from "@/lib/ui/viz/RadarChart";
 import { ScatterChart } from "@/lib/ui/viz/ScatterChart";
-import { DataExplorerStateManager } from "@/views/DataExplorerApp/DataExplorerStateManager/DataExplorerStateManager";
+import {
+  DataExplorerStateManager,
+} from "@/views/DataExplorerApp/DataExplorerStateManager/DataExplorerStateManager";
+import { DangerText } from "@/lib/ui/text/DangerText";
 import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types";
 
 type Props = {
@@ -26,7 +33,7 @@ type Props = {
   data: UnknownDataFrame;
 };
 
-// Reusable XY schema “blocks”
+// Reusable XY schema "blocks"
 const XAxisKeySchema = string({
   error: (issue) => {
     return issue.input === undefined ?
@@ -41,8 +48,28 @@ const YAxisKeySchema = string({
       : "Invalid Y axis selected";
   },
 });
+const NameKeySchema = string({
+  error: (issue) => {
+    return issue.input === undefined ?
+        "You haven't chosen a name column"
+      : "Invalid name column selected";
+  },
+});
+const ValueKeySchema = string({
+  error: (issue) => {
+    return issue.input === undefined ?
+        "You haven't chosen a value column"
+      : "Invalid value column selected";
+  },
+});
+const SizeKeySchema = string({
+  error: (issue) => {
+    return issue.input === undefined ?
+        "You haven't chosen a size column"
+      : "Invalid size column selected";
+  },
+});
 
-// Chart-specific schemas (can diverge later)
 const BarChartConfigSchema = object({
   xAxisKey: XAxisKeySchema,
   yAxisKey: YAxisKeySchema,
@@ -53,9 +80,35 @@ const LineChartConfigSchema = object({
   yAxisKey: YAxisKeySchema,
 });
 
+const AreaChartConfigSchema = object({
+  xAxisKey: XAxisKeySchema,
+  yAxisKey: YAxisKeySchema,
+});
+
 const ScatterPlotConfigSchema = object({
   xAxisKey: XAxisKeySchema,
   yAxisKey: YAxisKeySchema,
+});
+
+const PieChartConfigSchema = object({
+  nameKey: NameKeySchema,
+  valueKey: ValueKeySchema,
+});
+
+const FunnelChartConfigSchema = object({
+  nameKey: NameKeySchema,
+  valueKey: ValueKeySchema,
+});
+
+const RadarChartConfigSchema = object({
+  nameKey: NameKeySchema,
+  valueKey: ValueKeySchema,
+});
+
+const BubbleChartConfigSchema = object({
+  xAxisKey: XAxisKeySchema,
+  yAxisKey: YAxisKeySchema,
+  sizeKey: SizeKeySchema,
 });
 
 export function VisualizationContainer({
@@ -90,12 +143,12 @@ export function VisualizationContainer({
             data={data}
             height={700}
             dateColumns={dateColumns}
+            withLegend={config.withLegend}
             {...validConfig}
           />
         );
       }
 
-      // generate the error message
       const errors = flattenError(error).fieldErrors;
       const errorMessages = objectValues(errors).flat();
       const errorBlock = (
@@ -140,6 +193,29 @@ export function VisualizationContainer({
             data={data}
             height={700}
             dateColumns={dateColumns}
+            withLegend={config.withLegend}
+            curveType={config.curveType}
+            {...validConfig}
+          />
+        );
+      }
+      return <DangerText>{prettifyError(error)}</DangerText>;
+    })
+    .with({ vizType: "area" }, (config) => {
+      const {
+        success,
+        data: validConfig,
+        error,
+      } = AreaChartConfigSchema.safeParse(config);
+
+      if (success) {
+        return (
+          <AreaChart
+            data={data}
+            height={700}
+            dateColumns={dateColumns}
+            withLegend={config.withLegend}
+            curveType={config.curveType}
             {...validConfig}
           />
         );
@@ -155,6 +231,83 @@ export function VisualizationContainer({
 
       if (success) {
         return <ScatterChart data={data} height={700} {...validConfig} />;
+      }
+      return <DangerText>{prettifyError(error)}</DangerText>;
+    })
+    .with({ vizType: "pie" }, (config) => {
+      const {
+        success,
+        data: validConfig,
+        error,
+      } = PieChartConfigSchema.safeParse(config);
+
+      if (success) {
+        return (
+          <PieChart
+            data={data}
+            nameKey={validConfig.nameKey}
+            valueKey={validConfig.valueKey}
+            isDonut={config.isDonut}
+            withLabels={config.withLabels}
+            labelsType={config.labelsType}
+          />
+        );
+      }
+      return <DangerText>{prettifyError(error)}</DangerText>;
+    })
+    .with({ vizType: "funnel" }, (config) => {
+      const {
+        success,
+        data: validConfig,
+        error,
+      } = FunnelChartConfigSchema.safeParse(config);
+
+      if (success) {
+        return (
+          <FunnelChart
+            data={data}
+            nameKey={validConfig.nameKey}
+            valueKey={validConfig.valueKey}
+          />
+        );
+      }
+      return <DangerText>{prettifyError(error)}</DangerText>;
+    })
+    .with({ vizType: "radar" }, (config) => {
+      const {
+        success,
+        data: validConfig,
+        error,
+      } = RadarChartConfigSchema.safeParse(config);
+
+      if (success) {
+        return (
+          <RadarChart
+            data={data}
+            nameKey={validConfig.nameKey}
+            valueKey={validConfig.valueKey}
+          />
+        );
+      }
+      return <DangerText>{prettifyError(error)}</DangerText>;
+    })
+    .with({ vizType: "bubble" }, (config) => {
+      const {
+        success,
+        data: validConfig,
+        error,
+      } = BubbleChartConfigSchema.safeParse(config);
+
+      if (success) {
+        return (
+          <BubbleChart
+            data={data}
+            height={700}
+            xAxisKey={validConfig.xAxisKey}
+            yAxisKey={validConfig.yAxisKey}
+            sizeKey={validConfig.sizeKey}
+          />
+        );
       }
       return <DangerText>{prettifyError(error)}</DangerText>;
     })

--- a/src/views/DataExplorerApp/VizSettingsForm/AreaChartForm.tsx
+++ b/src/views/DataExplorerApp/VizSettingsForm/AreaChartForm.tsx
@@ -1,16 +1,16 @@
+import { Select } from "@ui/inputs/Select/Select";
 import { makeSelectOptions } from "@ui/inputs/Select/makeSelectOptions";
 import { propPasses } from "@utils/objects/hofs/propPasses/propPasses";
 import { AvaDataTypes } from "$/models/datasets/AvaDataType/AvaDataTypes";
 import { Switch } from "@mantine/core";
 import { useMemo } from "react";
-import { Select } from "@ui/inputs/Select/Select";
 import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types";
-import type { LineChartVizConfig } from "$/models/vizs/LineChartVizConfig/LineChartVizConfig.types";
+import type { AreaChartVizConfig } from "$/models/vizs/AreaChartVizConfig/AreaChartVizConfig.types";
 
 type Props = {
   fields: readonly QueryResultColumn[];
-  config: LineChartVizConfig;
-  onConfigChange: (newConfig: LineChartVizConfig) => void;
+  config: AreaChartVizConfig;
+  onConfigChange: (newConfig: AreaChartVizConfig) => void;
 };
 
 const CURVE_TYPE_OPTIONS = [
@@ -20,7 +20,7 @@ const CURVE_TYPE_OPTIONS = [
   { label: "Step", value: "step" },
 ];
 
-export function LineChartForm({
+export function AreaChartForm({
   fields,
   config,
   onConfigChange,
@@ -47,15 +47,11 @@ export function LineChartForm({
         value={xAxisKey}
         disabled={fieldOptions.length === 0}
         placeholder={
-          fieldOptions.length === 0 ?
-            "No fields have been queried"
+          fieldOptions.length === 0 ? "No fields have been queried"
           : "Select a field"
         }
         onChange={(field) => {
-          return onConfigChange({
-            ...config,
-            xAxisKey: field ?? undefined,
-          });
+          onConfigChange({ ...config, xAxisKey: field ?? undefined });
         }}
       />
 
@@ -72,10 +68,7 @@ export function LineChartForm({
           : "Select a field"
         }
         onChange={(field) => {
-          return onConfigChange({
-            ...config,
-            yAxisKey: field ?? undefined,
-          });
+          onConfigChange({ ...config, yAxisKey: field ?? undefined });
         }}
       />
 
@@ -102,7 +95,7 @@ export function LineChartForm({
         checked={withLegend}
         mt="sm"
         onChange={(event) => {
-          return onConfigChange({
+          onConfigChange({
             ...config,
             withLegend: event.currentTarget.checked,
           });

--- a/src/views/DataExplorerApp/VizSettingsForm/AreaChartForm.tsx
+++ b/src/views/DataExplorerApp/VizSettingsForm/AreaChartForm.tsx
@@ -1,8 +1,9 @@
+import { ColorInput, Switch } from "@mantine/core";
 import { Select } from "@ui/inputs/Select/Select";
 import { makeSelectOptions } from "@ui/inputs/Select/makeSelectOptions";
 import { propPasses } from "@utils/objects/hofs/propPasses/propPasses";
 import { AvaDataTypes } from "$/models/datasets/AvaDataType/AvaDataTypes";
-import { Switch } from "@mantine/core";
+import { CHART_COLOR_SWATCHES } from "@/lib/ui/viz/ChartConstants";
 import { useMemo } from "react";
 import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types";
 import type { AreaChartVizConfig } from "$/models/vizs/AreaChartVizConfig/AreaChartVizConfig.types";
@@ -99,6 +100,18 @@ export function AreaChartForm({
             ...config,
             withLegend: event.currentTarget.checked,
           });
+        }}
+      />
+
+      <ColorInput
+        label={yAxisKey ?? "Series"}
+        value={config.color ?? ""}
+        mt="sm"
+        swatches={CHART_COLOR_SWATCHES}
+        withEyeDropper={false}
+        format="hex"
+        onChange={(value) => {
+          onConfigChange({ ...config, color: value || undefined });
         }}
       />
     </>

--- a/src/views/DataExplorerApp/VizSettingsForm/BarChartForm.tsx
+++ b/src/views/DataExplorerApp/VizSettingsForm/BarChartForm.tsx
@@ -1,8 +1,9 @@
-import { Switch, Tooltip } from "@mantine/core";
+import { ColorInput, Switch, Tooltip } from "@mantine/core";
 import { makeSelectOptions } from "@ui/inputs/Select/makeSelectOptions";
 import { Select } from "@ui/inputs/Select/Select";
 import { propPasses } from "@utils/objects/hofs/propPasses/propPasses";
 import { AvaDataTypes } from "$/models/datasets/AvaDataType/AvaDataTypes";
+import { CHART_COLOR_SWATCHES } from "@/lib/ui/viz/ChartConstants";
 import { useMemo } from "react";
 import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types";
 import type { BarChartVizConfig } from "$/models/vizs/BarChartVizConfig/BarChartVizConfig.types";
@@ -97,6 +98,18 @@ export function BarChartForm({
             ...config,
             withLegend: event.currentTarget.checked,
           });
+        }}
+      />
+
+      <ColorInput
+        label={yAxisKey ?? "Series"}
+        value={config.color ?? ""}
+        mt="sm"
+        swatches={CHART_COLOR_SWATCHES}
+        withEyeDropper={false}
+        format="hex"
+        onChange={(value) => {
+          onConfigChange({ ...config, color: value || undefined });
         }}
       />
     </>

--- a/src/views/DataExplorerApp/VizSettingsForm/BarChartForm.tsx
+++ b/src/views/DataExplorerApp/VizSettingsForm/BarChartForm.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from "@mantine/core";
+import { Switch, Tooltip } from "@mantine/core";
 import { makeSelectOptions } from "@ui/inputs/Select/makeSelectOptions";
 import { Select } from "@ui/inputs/Select/Select";
 import { propPasses } from "@utils/objects/hofs/propPasses/propPasses";
@@ -34,7 +34,7 @@ export function BarChartForm({
       },
     );
   }, [fields]);
-  const { xAxisKey, yAxisKey } = config;
+  const { xAxisKey, yAxisKey, withLegend } = config;
   const xAxisDisabled = fieldOptions.length === 0;
   const yAxisDisabled =
     fieldOptions.length === 0 || numericFieldOptions.length === 0;
@@ -87,6 +87,18 @@ export function BarChartForm({
           }}
         />
       </Tooltip>
+
+      <Switch
+        label="Show legend"
+        checked={withLegend}
+        mt="sm"
+        onChange={(event) => {
+          onConfigChange({
+            ...config,
+            withLegend: event.currentTarget.checked,
+          });
+        }}
+      />
     </>
   );
 }

--- a/src/views/DataExplorerApp/VizSettingsForm/BubbleChartForm.tsx
+++ b/src/views/DataExplorerApp/VizSettingsForm/BubbleChartForm.tsx
@@ -1,0 +1,80 @@
+import { Select } from "@ui/inputs/Select/Select";
+import { makeSelectOptions } from "@ui/inputs/Select/makeSelectOptions";
+import { propPasses } from "@utils/objects/hofs/propPasses/propPasses";
+import { AvaDataTypes } from "$/models/datasets/AvaDataType/AvaDataTypes";
+import { useMemo } from "react";
+import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types";
+import type { BubbleChartVizConfig } from "$/models/vizs/BubbleChartVizConfig/BubbleChartVizConfig.types";
+
+type Props = {
+  fields: readonly QueryResultColumn[];
+  config: BubbleChartVizConfig;
+  onConfigChange: (newConfig: BubbleChartVizConfig) => void;
+};
+
+export function BubbleChartForm({
+  fields,
+  config,
+  onConfigChange,
+}: Props): JSX.Element {
+  const numericFieldOptions = useMemo(() => {
+    return makeSelectOptions(
+      fields.filter(propPasses("dataType", AvaDataTypes.isNumeric)),
+      { valueKey: "name", labelKey: "name" },
+    );
+  }, [fields]);
+
+  const { xAxisKey, yAxisKey, sizeKey } = config;
+
+  return (
+    <>
+      <Select
+        allowDeselect
+        data={numericFieldOptions}
+        label="X Axis (numeric)"
+        value={xAxisKey}
+        disabled={numericFieldOptions.length === 0}
+        placeholder={
+          numericFieldOptions.length === 0 ?
+            "There are no numeric columns"
+          : "Select a column"
+        }
+        onChange={(field) => {
+          onConfigChange({ ...config, xAxisKey: field ?? undefined });
+        }}
+      />
+
+      <Select
+        allowDeselect
+        data={numericFieldOptions}
+        label="Y Axis (numeric)"
+        value={yAxisKey}
+        disabled={numericFieldOptions.length === 0}
+        placeholder={
+          numericFieldOptions.length === 0 ?
+            "There are no numeric columns"
+          : "Select a column"
+        }
+        onChange={(field) => {
+          onConfigChange({ ...config, yAxisKey: field ?? undefined });
+        }}
+      />
+
+      <Select
+        allowDeselect
+        data={numericFieldOptions}
+        label="Bubble size (numeric)"
+        value={sizeKey}
+        disabled={numericFieldOptions.length === 0}
+        placeholder={
+          numericFieldOptions.length === 0 ?
+            "There are no numeric columns"
+          : "Select a column"
+        }
+        onChange={(field) => {
+          onConfigChange({ ...config, sizeKey: field ?? undefined });
+        }}
+      />
+    </>
+  );
+}

--- a/src/views/DataExplorerApp/VizSettingsForm/FunnelChartForm.tsx
+++ b/src/views/DataExplorerApp/VizSettingsForm/FunnelChartForm.tsx
@@ -1,0 +1,67 @@
+import { Select } from "@ui/inputs/Select/Select";
+import { makeSelectOptions } from "@ui/inputs/Select/makeSelectOptions";
+import { propPasses } from "@utils/objects/hofs/propPasses/propPasses";
+import { AvaDataTypes } from "$/models/datasets/AvaDataType/AvaDataTypes";
+import { useMemo } from "react";
+import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types";
+import type { FunnelChartVizConfig } from "$/models/vizs/FunnelChartVizConfig/FunnelChartVizConfig.types";
+
+type Props = {
+  fields: readonly QueryResultColumn[];
+  config: FunnelChartVizConfig;
+  onConfigChange: (newConfig: FunnelChartVizConfig) => void;
+};
+
+export function FunnelChartForm({
+  fields,
+  config,
+  onConfigChange,
+}: Props): JSX.Element {
+  const fieldOptions = useMemo(() => {
+    return makeSelectOptions(fields, { valueKey: "name", labelKey: "name" });
+  }, [fields]);
+
+  const numericFieldOptions = useMemo(() => {
+    return makeSelectOptions(
+      fields.filter(propPasses("dataType", AvaDataTypes.isNumeric)),
+      { valueKey: "name", labelKey: "name" },
+    );
+  }, [fields]);
+
+  const { nameKey, valueKey } = config;
+
+  return (
+    <>
+      <Select
+        allowDeselect
+        data={fieldOptions}
+        label="Name column"
+        value={nameKey}
+        disabled={fieldOptions.length === 0}
+        placeholder={
+          fieldOptions.length === 0 ? "No columns are available"
+          : "Select a column"
+        }
+        onChange={(field) => {
+          onConfigChange({ ...config, nameKey: field ?? undefined });
+        }}
+      />
+
+      <Select
+        allowDeselect
+        data={numericFieldOptions}
+        label="Value column"
+        value={valueKey}
+        disabled={numericFieldOptions.length === 0}
+        placeholder={
+          numericFieldOptions.length === 0 ?
+            "There are no numeric columns"
+          : "Select a column"
+        }
+        onChange={(field) => {
+          onConfigChange({ ...config, valueKey: field ?? undefined });
+        }}
+      />
+    </>
+  );
+}

--- a/src/views/DataExplorerApp/VizSettingsForm/FunnelChartForm.tsx
+++ b/src/views/DataExplorerApp/VizSettingsForm/FunnelChartForm.tsx
@@ -1,20 +1,25 @@
+import { ColorInput, Divider } from "@mantine/core";
 import { Select } from "@ui/inputs/Select/Select";
 import { makeSelectOptions } from "@ui/inputs/Select/makeSelectOptions";
 import { propPasses } from "@utils/objects/hofs/propPasses/propPasses";
 import { AvaDataTypes } from "$/models/datasets/AvaDataType/AvaDataTypes";
+import { CHART_COLOR_SWATCHES } from "@/lib/ui/viz/ChartConstants";
 import { useMemo } from "react";
+import type { UnknownDataFrame } from "@utils/types/common.types";
 import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types";
 import type { FunnelChartVizConfig } from "$/models/vizs/FunnelChartVizConfig/FunnelChartVizConfig.types";
 
 type Props = {
   fields: readonly QueryResultColumn[];
   config: FunnelChartVizConfig;
+  data: UnknownDataFrame;
   onConfigChange: (newConfig: FunnelChartVizConfig) => void;
 };
 
 export function FunnelChartForm({
   fields,
   config,
+  data,
   onConfigChange,
 }: Props): JSX.Element {
   const fieldOptions = useMemo(() => {
@@ -27,6 +32,20 @@ export function FunnelChartForm({
       { valueKey: "name", labelKey: "name" },
     );
   }, [fields]);
+
+  const sliceNames = useMemo(() => {
+    if (!config.nameKey) {
+      return [];
+    }
+    const seen = new Set<string>();
+    data.forEach((row) => {
+      const name = String(row[config.nameKey ?? ""] ?? "");
+      if (name) {
+        seen.add(name);
+      }
+    });
+    return Array.from(seen);
+  }, [data, config.nameKey]);
 
   const { nameKey, valueKey } = config;
 
@@ -62,6 +81,34 @@ export function FunnelChartForm({
           onConfigChange({ ...config, valueKey: field ?? undefined });
         }}
       />
+
+      {sliceNames.length > 0 ? (
+        <>
+          <Divider label="Slice colors" mt="sm" mb="xs" />
+          {sliceNames.map((name) => {
+            return (
+              <ColorInput
+                key={name}
+                label={name}
+                value={config.seriesColors?.[name] ?? ""}
+                mt="xs"
+                swatches={CHART_COLOR_SWATCHES}
+                withEyeDropper={false}
+                format="hex"
+                onChange={(value) => {
+                  onConfigChange({
+                    ...config,
+                    seriesColors: {
+                      ...config.seriesColors,
+                      [name]: value || undefined,
+                    } as Record<string, string>,
+                  });
+                }}
+              />
+            );
+          })}
+        </>
+      ) : null}
     </>
   );
 }

--- a/src/views/DataExplorerApp/VizSettingsForm/LineChartForm.tsx
+++ b/src/views/DataExplorerApp/VizSettingsForm/LineChartForm.tsx
@@ -1,7 +1,8 @@
+import { ColorInput, Switch } from "@mantine/core";
 import { makeSelectOptions } from "@ui/inputs/Select/makeSelectOptions";
 import { propPasses } from "@utils/objects/hofs/propPasses/propPasses";
 import { AvaDataTypes } from "$/models/datasets/AvaDataType/AvaDataTypes";
-import { Switch } from "@mantine/core";
+import { CHART_COLOR_SWATCHES } from "@/lib/ui/viz/ChartConstants";
 import { useMemo } from "react";
 import { Select } from "@ui/inputs/Select/Select";
 import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types";
@@ -106,6 +107,18 @@ export function LineChartForm({
             ...config,
             withLegend: event.currentTarget.checked,
           });
+        }}
+      />
+
+      <ColorInput
+        label={yAxisKey ?? "Series"}
+        value={config.color ?? ""}
+        mt="sm"
+        swatches={CHART_COLOR_SWATCHES}
+        withEyeDropper={false}
+        format="hex"
+        onChange={(value) => {
+          onConfigChange({ ...config, color: value || undefined });
         }}
       />
     </>

--- a/src/views/DataExplorerApp/VizSettingsForm/PieChartForm.tsx
+++ b/src/views/DataExplorerApp/VizSettingsForm/PieChartForm.tsx
@@ -1,0 +1,109 @@
+import { Select } from "@ui/inputs/Select/Select";
+import { makeSelectOptions } from "@ui/inputs/Select/makeSelectOptions";
+import { propPasses } from "@utils/objects/hofs/propPasses/propPasses";
+import { AvaDataTypes } from "$/models/datasets/AvaDataType/AvaDataTypes";
+import { Switch } from "@mantine/core";
+import { useMemo } from "react";
+import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types";
+import type { PieChartVizConfig } from "$/models/vizs/PieChartVizConfig/PieChartVizConfig.types";
+
+type Props = {
+  fields: readonly QueryResultColumn[];
+  config: PieChartVizConfig;
+  onConfigChange: (newConfig: PieChartVizConfig) => void;
+};
+
+export function PieChartForm({
+  fields,
+  config,
+  onConfigChange,
+}: Props): JSX.Element {
+  const fieldOptions = useMemo(() => {
+    return makeSelectOptions(fields, { valueKey: "name", labelKey: "name" });
+  }, [fields]);
+
+  const numericFieldOptions = useMemo(() => {
+    return makeSelectOptions(
+      fields.filter(propPasses("dataType", AvaDataTypes.isNumeric)),
+      { valueKey: "name", labelKey: "name" },
+    );
+  }, [fields]);
+
+  const labelsTypeOptions = [
+    { label: "Value", value: "value" },
+    { label: "Percent", value: "percent" },
+  ];
+
+  const { nameKey, valueKey, isDonut, withLabels, labelsType } = config;
+
+  return (
+    <>
+      <Select
+        allowDeselect
+        data={fieldOptions}
+        label="Name column"
+        value={nameKey}
+        disabled={fieldOptions.length === 0}
+        placeholder={
+          fieldOptions.length === 0 ? "No columns are available"
+          : "Select a column"
+        }
+        onChange={(field) => {
+          onConfigChange({ ...config, nameKey: field ?? undefined });
+        }}
+      />
+
+      <Select
+        allowDeselect
+        data={numericFieldOptions}
+        label="Value column"
+        value={valueKey}
+        disabled={numericFieldOptions.length === 0}
+        placeholder={
+          numericFieldOptions.length === 0 ?
+            "There are no numeric columns"
+          : "Select a column"
+        }
+        onChange={(field) => {
+          onConfigChange({ ...config, valueKey: field ?? undefined });
+        }}
+      />
+
+      <Switch
+        label="Donut style"
+        checked={isDonut}
+        mt="sm"
+        onChange={(event) => {
+          onConfigChange({ ...config, isDonut: event.currentTarget.checked });
+        }}
+      />
+
+      <Switch
+        label="Show labels"
+        checked={withLabels}
+        mt="sm"
+        onChange={(event) => {
+          onConfigChange({
+            ...config,
+            withLabels: event.currentTarget.checked,
+          });
+        }}
+      />
+
+      {withLabels ? (
+        <Select
+          allowDeselect={false}
+          data={labelsTypeOptions}
+          label="Label type"
+          value={labelsType}
+          mt="xs"
+          onChange={(value) => {
+            if (value === "value" || value === "percent") {
+              onConfigChange({ ...config, labelsType: value });
+            }
+          }}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/src/views/DataExplorerApp/VizSettingsForm/PieChartForm.tsx
+++ b/src/views/DataExplorerApp/VizSettingsForm/PieChartForm.tsx
@@ -1,21 +1,25 @@
+import { ColorInput, Divider, Switch } from "@mantine/core";
 import { Select } from "@ui/inputs/Select/Select";
 import { makeSelectOptions } from "@ui/inputs/Select/makeSelectOptions";
 import { propPasses } from "@utils/objects/hofs/propPasses/propPasses";
 import { AvaDataTypes } from "$/models/datasets/AvaDataType/AvaDataTypes";
-import { Switch } from "@mantine/core";
+import { CHART_COLOR_SWATCHES } from "@/lib/ui/viz/ChartConstants";
 import { useMemo } from "react";
+import type { UnknownDataFrame } from "@utils/types/common.types";
 import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types";
 import type { PieChartVizConfig } from "$/models/vizs/PieChartVizConfig/PieChartVizConfig.types";
 
 type Props = {
   fields: readonly QueryResultColumn[];
   config: PieChartVizConfig;
+  data: UnknownDataFrame;
   onConfigChange: (newConfig: PieChartVizConfig) => void;
 };
 
 export function PieChartForm({
   fields,
   config,
+  data,
   onConfigChange,
 }: Props): JSX.Element {
   const fieldOptions = useMemo(() => {
@@ -28,6 +32,20 @@ export function PieChartForm({
       { valueKey: "name", labelKey: "name" },
     );
   }, [fields]);
+
+  const sliceNames = useMemo(() => {
+    if (!config.nameKey) {
+      return [];
+    }
+    const seen = new Set<string>();
+    data.forEach((row) => {
+      const name = String(row[config.nameKey ?? ""] ?? "");
+      if (name) {
+        seen.add(name);
+      }
+    });
+    return Array.from(seen);
+  }, [data, config.nameKey]);
 
   const labelsTypeOptions = [
     { label: "Value", value: "value" },
@@ -103,6 +121,34 @@ export function PieChartForm({
             }
           }}
         />
+      ) : null}
+
+      {sliceNames.length > 0 ? (
+        <>
+          <Divider label="Slice colors" mt="sm" mb="xs" />
+          {sliceNames.map((name) => {
+            return (
+              <ColorInput
+                key={name}
+                label={name}
+                value={config.seriesColors?.[name] ?? ""}
+                mt="xs"
+                swatches={CHART_COLOR_SWATCHES}
+                withEyeDropper={false}
+                format="hex"
+                onChange={(value) => {
+                  onConfigChange({
+                    ...config,
+                    seriesColors: {
+                      ...config.seriesColors,
+                      [name]: value || undefined,
+                    } as Record<string, string>,
+                  });
+                }}
+              />
+            );
+          })}
+        </>
       ) : null}
     </>
   );

--- a/src/views/DataExplorerApp/VizSettingsForm/RadarChartForm.tsx
+++ b/src/views/DataExplorerApp/VizSettingsForm/RadarChartForm.tsx
@@ -1,7 +1,9 @@
+import { ColorInput } from "@mantine/core";
 import { Select } from "@ui/inputs/Select/Select";
 import { makeSelectOptions } from "@ui/inputs/Select/makeSelectOptions";
 import { propPasses } from "@utils/objects/hofs/propPasses/propPasses";
 import { AvaDataTypes } from "$/models/datasets/AvaDataType/AvaDataTypes";
+import { CHART_COLOR_SWATCHES } from "@/lib/ui/viz/ChartConstants";
 import { useMemo } from "react";
 import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types";
 import type { RadarChartVizConfig } from "$/models/vizs/RadarChartVizConfig/RadarChartVizConfig.types";
@@ -60,6 +62,18 @@ export function RadarChartForm({
         }
         onChange={(field) => {
           onConfigChange({ ...config, valueKey: field ?? undefined });
+        }}
+      />
+
+      <ColorInput
+        label={valueKey ?? "Series"}
+        value={config.color ?? ""}
+        mt="sm"
+        swatches={CHART_COLOR_SWATCHES}
+        withEyeDropper={false}
+        format="hex"
+        onChange={(value) => {
+          onConfigChange({ ...config, color: value || undefined });
         }}
       />
     </>

--- a/src/views/DataExplorerApp/VizSettingsForm/RadarChartForm.tsx
+++ b/src/views/DataExplorerApp/VizSettingsForm/RadarChartForm.tsx
@@ -1,0 +1,67 @@
+import { Select } from "@ui/inputs/Select/Select";
+import { makeSelectOptions } from "@ui/inputs/Select/makeSelectOptions";
+import { propPasses } from "@utils/objects/hofs/propPasses/propPasses";
+import { AvaDataTypes } from "$/models/datasets/AvaDataType/AvaDataTypes";
+import { useMemo } from "react";
+import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types";
+import type { RadarChartVizConfig } from "$/models/vizs/RadarChartVizConfig/RadarChartVizConfig.types";
+
+type Props = {
+  fields: readonly QueryResultColumn[];
+  config: RadarChartVizConfig;
+  onConfigChange: (newConfig: RadarChartVizConfig) => void;
+};
+
+export function RadarChartForm({
+  fields,
+  config,
+  onConfigChange,
+}: Props): JSX.Element {
+  const fieldOptions = useMemo(() => {
+    return makeSelectOptions(fields, { valueKey: "name", labelKey: "name" });
+  }, [fields]);
+
+  const numericFieldOptions = useMemo(() => {
+    return makeSelectOptions(
+      fields.filter(propPasses("dataType", AvaDataTypes.isNumeric)),
+      { valueKey: "name", labelKey: "name" },
+    );
+  }, [fields]);
+
+  const { nameKey, valueKey } = config;
+
+  return (
+    <>
+      <Select
+        allowDeselect
+        data={fieldOptions}
+        label="Category column"
+        value={nameKey}
+        disabled={fieldOptions.length === 0}
+        placeholder={
+          fieldOptions.length === 0 ? "No columns are available"
+          : "Select a column"
+        }
+        onChange={(field) => {
+          onConfigChange({ ...config, nameKey: field ?? undefined });
+        }}
+      />
+
+      <Select
+        allowDeselect
+        data={numericFieldOptions}
+        label="Value column"
+        value={valueKey}
+        disabled={numericFieldOptions.length === 0}
+        placeholder={
+          numericFieldOptions.length === 0 ?
+            "There are no numeric columns"
+          : "Select a column"
+        }
+        onChange={(field) => {
+          onConfigChange({ ...config, valueKey: field ?? undefined });
+        }}
+      />
+    </>
+  );
+}

--- a/src/views/DataExplorerApp/VizSettingsForm/VizSettingsForm.tsx
+++ b/src/views/DataExplorerApp/VizSettingsForm/VizSettingsForm.tsx
@@ -2,10 +2,33 @@ import { Box } from "@mantine/core";
 import { Select, SelectData } from "@ui/inputs/Select/Select";
 import { VizConfigs, VizTypes } from "$/models/vizs/VizConfig/VizConfigs";
 import { match } from "ts-pattern";
-import { DataExplorerStateManager } from "@/views/DataExplorerApp/DataExplorerStateManager/DataExplorerStateManager";
-import { BarChartForm } from "@/views/DataExplorerApp/VizSettingsForm/BarChartForm";
-import { LineChartForm } from "@/views/DataExplorerApp/VizSettingsForm/LineChartForm";
-import { ScatterChartForm } from "@/views/DataExplorerApp/VizSettingsForm/ScatterChartForm";
+import {
+  DataExplorerStateManager,
+} from "@/views/DataExplorerApp/DataExplorerStateManager/DataExplorerStateManager";
+import {
+  AreaChartForm,
+} from "@/views/DataExplorerApp/VizSettingsForm/AreaChartForm";
+import {
+  BarChartForm,
+} from "@/views/DataExplorerApp/VizSettingsForm/BarChartForm";
+import {
+  BubbleChartForm,
+} from "@/views/DataExplorerApp/VizSettingsForm/BubbleChartForm";
+import {
+  FunnelChartForm,
+} from "@/views/DataExplorerApp/VizSettingsForm/FunnelChartForm";
+import {
+  LineChartForm,
+} from "@/views/DataExplorerApp/VizSettingsForm/LineChartForm";
+import {
+  PieChartForm,
+} from "@/views/DataExplorerApp/VizSettingsForm/PieChartForm";
+import {
+  RadarChartForm,
+} from "@/views/DataExplorerApp/VizSettingsForm/RadarChartForm";
+import {
+  ScatterChartForm,
+} from "@/views/DataExplorerApp/VizSettingsForm/ScatterChartForm";
 import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types";
 import type { VizType } from "$/models/vizs/VizConfig/VizConfig.types";
 
@@ -62,9 +85,64 @@ export function VizSettingsForm({ columns }: Props): JSX.Element {
             />
           );
         })
+        .with({ vizType: "area" }, (config) => {
+          return (
+            <AreaChartForm
+              fields={columns}
+              config={config}
+              onConfigChange={(newConfig) => {
+                dispatch.setVizConfig({ ...config, ...newConfig });
+              }}
+            />
+          );
+        })
         .with({ vizType: "scatter" }, (config) => {
           return (
             <ScatterChartForm
+              fields={columns}
+              config={config}
+              onConfigChange={(newConfig) => {
+                dispatch.setVizConfig({ ...config, ...newConfig });
+              }}
+            />
+          );
+        })
+        .with({ vizType: "pie" }, (config) => {
+          return (
+            <PieChartForm
+              fields={columns}
+              config={config}
+              onConfigChange={(newConfig) => {
+                dispatch.setVizConfig({ ...config, ...newConfig });
+              }}
+            />
+          );
+        })
+        .with({ vizType: "funnel" }, (config) => {
+          return (
+            <FunnelChartForm
+              fields={columns}
+              config={config}
+              onConfigChange={(newConfig) => {
+                dispatch.setVizConfig({ ...config, ...newConfig });
+              }}
+            />
+          );
+        })
+        .with({ vizType: "radar" }, (config) => {
+          return (
+            <RadarChartForm
+              fields={columns}
+              config={config}
+              onConfigChange={(newConfig) => {
+                dispatch.setVizConfig({ ...config, ...newConfig });
+              }}
+            />
+          );
+        })
+        .with({ vizType: "bubble" }, (config) => {
+          return (
+            <BubbleChartForm
               fields={columns}
               config={config}
               onConfigChange={(newConfig) => {

--- a/src/views/DataExplorerApp/VizSettingsForm/VizSettingsForm.tsx
+++ b/src/views/DataExplorerApp/VizSettingsForm/VizSettingsForm.tsx
@@ -29,14 +29,16 @@ import {
 import {
   ScatterChartForm,
 } from "@/views/DataExplorerApp/VizSettingsForm/ScatterChartForm";
+import type { UnknownDataFrame } from "@utils/types/common.types";
 import type { QueryResultColumn } from "$/models/queries/QueryResult/QueryResult.types";
 import type { VizType } from "$/models/vizs/VizConfig/VizConfig.types";
 
 type Props = {
   columns: readonly QueryResultColumn[];
+  data: UnknownDataFrame;
 };
 
-export function VizSettingsForm({ columns }: Props): JSX.Element {
+export function VizSettingsForm({ columns, data }: Props): JSX.Element {
   const [{ vizConfig }, dispatch] = DataExplorerStateManager.useContext();
   const vizTypeOptions: SelectData<VizType> = VizTypes.map((vizType) => {
     return {
@@ -112,6 +114,7 @@ export function VizSettingsForm({ columns }: Props): JSX.Element {
             <PieChartForm
               fields={columns}
               config={config}
+              data={data}
               onConfigChange={(newConfig) => {
                 dispatch.setVizConfig({ ...config, ...newConfig });
               }}
@@ -123,6 +126,7 @@ export function VizSettingsForm({ columns }: Props): JSX.Element {
             <FunnelChartForm
               fields={columns}
               config={config}
+              data={data}
               onConfigChange={(newConfig) => {
                 dispatch.setVizConfig({ ...config, ...newConfig });
               }}

--- a/src/views/DataExplorerApp/dataExplorerURLHydration.test.ts
+++ b/src/views/DataExplorerApp/dataExplorerURLHydration.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import type { VizConfig } from "$/models/vizs/VizConfig/VizConfig.types";
+import {
+  shouldDeferURLHydrationForStructuredLoading,
+  urlSearchHasHydrateableExplorerKeys,
+} from "@/views/DataExplorerApp/dataExplorerURLHydration";
+import type { ParsedURLState } from "@/views/DataExplorerApp/DataExplorerURLState";
+import type { OpenDatasetInfo } from "@/views/DataExplorerApp/DataExplorerStateManager/DataExplorerStateManager";
+
+const _minimalBarViz: VizConfig = {
+  vizType: "bar",
+  xAxisKey: "a",
+  yAxisKey: "b",
+  withLegend: false,
+};
+
+function _parsed(overrides: Partial<ParsedURLState> = {}): ParsedURLState {
+  return { ...overrides };
+}
+
+describe("urlSearchHasHydrateableExplorerKeys", () => {
+  it("returns false for an empty parsed state", () => {
+    expect(urlSearchHasHydrateableExplorerKeys(_parsed())).toBe(false);
+  });
+
+  it("returns true when dsId is set", () => {
+    expect(urlSearchHasHydrateableExplorerKeys(_parsed({ dsId: "a" }))).toBe(
+      true,
+    );
+  });
+
+  it("returns true when rawSQL is set", () => {
+    expect(urlSearchHasHydrateableExplorerKeys(_parsed({ rawSQL: "x" }))).toBe(
+      true,
+    );
+  });
+
+  it("returns true when vizConfig is set", () => {
+    expect(
+      urlSearchHasHydrateableExplorerKeys(
+        _parsed({ vizConfig: _minimalBarViz }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when only openDataset is set (not a hydrate trigger)", () => {
+    const openDataset = {
+      datasetId: "d",
+      name: "n",
+      virtualDatasetId: "v",
+    } as OpenDatasetInfo;
+    expect(
+      urlSearchHasHydrateableExplorerKeys(_parsed({ openDataset })),
+    ).toBe(false);
+  });
+});
+
+describe("shouldDeferURLHydrationForStructuredLoading", () => {
+  const DS = { id: "ds-1" };
+
+  it("does not defer when rawSQL is set even if dsId is unresolved", () => {
+    expect(
+      shouldDeferURLHydrationForStructuredLoading({
+        urlState: _parsed({ dsId: "missing", rawSQL: "SELECT 1" }),
+        restoredDataSource: undefined,
+        needsColumns: true,
+        datasetColumns: undefined,
+        entityFieldConfigs: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("defers when structured dsId has no restored data source yet", () => {
+    expect(
+      shouldDeferURLHydrationForStructuredLoading({
+        urlState: _parsed({ dsId: "x" }),
+        restoredDataSource: undefined,
+        needsColumns: false,
+        datasetColumns: undefined,
+        entityFieldConfigs: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not defer once restored data source exists", () => {
+    expect(
+      shouldDeferURLHydrationForStructuredLoading({
+        urlState: _parsed({ dsId: "x" }),
+        restoredDataSource: DS,
+        needsColumns: false,
+        datasetColumns: undefined,
+        entityFieldConfigs: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("defers when columns are needed but neither column list is loaded", () => {
+    expect(
+      shouldDeferURLHydrationForStructuredLoading({
+        urlState: _parsed({ dsId: "x", colNames: ["a"] }),
+        restoredDataSource: DS,
+        needsColumns: true,
+        datasetColumns: undefined,
+        entityFieldConfigs: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not defer when dataset columns have loaded", () => {
+    expect(
+      shouldDeferURLHydrationForStructuredLoading({
+        urlState: _parsed({ dsId: "x", colNames: ["a"] }),
+        restoredDataSource: DS,
+        needsColumns: true,
+        datasetColumns: [{ id: "c1" }],
+        entityFieldConfigs: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not defer when entity field configs have loaded", () => {
+    expect(
+      shouldDeferURLHydrationForStructuredLoading({
+        urlState: _parsed({ dsId: "x", colNames: ["a"] }),
+        restoredDataSource: DS,
+        needsColumns: true,
+        datasetColumns: undefined,
+        entityFieldConfigs: [{ id: "f1" }],
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/views/DataExplorerApp/dataExplorerURLHydration.ts
+++ b/src/views/DataExplorerApp/dataExplorerURLHydration.ts
@@ -1,0 +1,48 @@
+import type { ParsedURLState } from "@/views/DataExplorerApp/DataExplorerURLState";
+
+type MinimalDataSource = { id: string };
+
+/**
+ * Returns true when the parsed URL carries at least one explorer key we may
+ * hydrate (`ds`, `sql`, or `vc`). Used with `isDefaultExplorerState` to decide
+ * first-mount hydration.
+ */
+export function urlSearchHasHydrateableExplorerKeys(
+  parsed: ParsedURLState,
+): boolean {
+  return Boolean(parsed.dsId ?? parsed.rawSQL ?? parsed.vizConfig);
+}
+
+type DeferStructuredHydrationOptions = {
+  urlState: ParsedURLState;
+  restoredDataSource: MinimalDataSource | undefined;
+  needsColumns: boolean;
+  datasetColumns: readonly unknown[] | undefined;
+  entityFieldConfigs: readonly unknown[] | undefined;
+};
+
+/**
+ * When true, the hydration effect should return early and wait for datasets /
+ * column metadata to load before applying structured URL state.
+ */
+export function shouldDeferURLHydrationForStructuredLoading(
+  options: DeferStructuredHydrationOptions,
+): boolean {
+  const restoreStructured = !options.urlState.rawSQL;
+  if (
+    restoreStructured &&
+    options.urlState.dsId &&
+    !options.restoredDataSource
+  ) {
+    return true;
+  }
+  if (
+    restoreStructured &&
+    options.needsColumns &&
+    !options.datasetColumns &&
+    !options.entityFieldConfigs
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/src/views/DataExplorerApp/useDataExplorerURLSync.ts
+++ b/src/views/DataExplorerApp/useDataExplorerURLSync.ts
@@ -1,0 +1,249 @@
+import { isNonNullish } from "@utils/guards/isNonNullish/isNonNullish";
+import { where } from "@utils/filters/where/where";
+import { QueryColumns } from "$/models/queries/QueryColumn/QueryColumns";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { DatasetColumnClient } from "@/clients/datasets/DatasetColumnClient";
+import { DatasetClient } from "@/clients/datasets/DatasetClient";
+import { EntityConfigClient } from "@/clients/entity-configs/EntityConfigClient";
+import { EntityFieldConfigClient } from "@/clients/entities/EntityFieldConfigClient";
+import { useCurrentWorkspace } from "@/hooks/workspaces/useCurrentWorkspace";
+import { DataExplorerStateManager } from "@/views/DataExplorerApp/DataExplorerStateManager/DataExplorerStateManager";
+import {
+  shouldDeferURLHydrationForStructuredLoading,
+  urlSearchHasHydrateableExplorerKeys,
+} from "@/views/DataExplorerApp/dataExplorerURLHydration";
+import {
+  isDefaultExplorerState,
+  parseURLSearch,
+  serializeStateToURL,
+} from "@/views/DataExplorerApp/DataExplorerURLState";
+import type { DataExplorerURLSearch } from "@/views/DataExplorerApp/DataExplorerURLState";
+
+type Options = {
+  urlSearch: DataExplorerURLSearch;
+  navigate: (options: {
+    search: DataExplorerURLSearch;
+    replace: boolean;
+  }) => void;
+};
+
+/**
+ * Manages two-way sync between the Data Explorer's in-memory state and the
+ * URL search params:
+ *
+ * - **Hydration (URL → state):** On first mount, if the store is still at
+ *   its default empty state, the hook restores data source, column
+ *   selections, aggregations, order-by, raw SQL, and viz config from the URL
+ *   params. If `sql` is present in the URL, only raw SQL (plus viz / open
+ *   dataset) is applied — `ds` and `cols` are ignored so a stale Manual Query
+ *   cannot block restore or conflict with the SQL text. Column objects are
+ *   re-fetched via TanStack Query (cached) and matched by
+ *   `baseColumn.name` when structured params are used.
+ *
+ * - **Persistence (state → URL):** After hydration is complete, every state
+ *   change is serialised back to the URL using `replace: true` so the browser
+ *   history stays clean.
+ */
+export function useDataExplorerURLSync({
+  urlSearch,
+  navigate,
+}: Options): void {
+  const state = DataExplorerStateManager.useState();
+  const dispatch = DataExplorerStateManager.useDispatch();
+  const workspace = useCurrentWorkspace();
+
+  const urlState = useMemo(() => {
+    return parseURLSearch(urlSearch);
+  }, [urlSearch]);
+
+  // Data source lookup — these are already fetched by QueryDataSourceSelect
+  // so TanStack Query will return cached results with no extra network call.
+  const [datasets] = DatasetClient.useGetAll(
+    where("workspace_id", "eq", workspace.id),
+  );
+  const [entityConfigs] = EntityConfigClient.useGetAll(
+    where("workspace_id", "eq", workspace.id),
+  );
+
+  const restoredDataSource = useMemo(() => {
+    if (!urlState.dsId) {
+      return undefined;
+    }
+    return [...(datasets ?? []), ...(entityConfigs ?? [])].find((ds) => {
+      return ds.id === urlState.dsId;
+    });
+  }, [urlState.dsId, datasets, entityConfigs]);
+
+  const needsColumns =
+    (urlState.colNames?.length ?? 0) > 0 && Boolean(urlState.dsId);
+
+  /**
+   * When the URL has `sql`, it wins — do not restore `ds` / cols from URL.
+   */
+  const restoreStructuredFromURL = !urlState.rawSQL;
+
+  const isDatasetSource = useMemo(() => {
+    return (
+      Boolean(restoredDataSource) &&
+      (datasets?.some((d) => {
+        return d.id === restoredDataSource?.id;
+      }) ?? false)
+    );
+  }, [restoredDataSource, datasets]);
+
+  const isEntityConfigSource = useMemo(() => {
+    return (
+      Boolean(restoredDataSource) &&
+      (entityConfigs?.some((e) => {
+        return e.id === restoredDataSource?.id;
+      }) ?? false)
+    );
+  }, [restoredDataSource, entityConfigs]);
+
+  const [datasetColumns] = DatasetColumnClient.useGetAll({
+    ...where("dataset_id", "eq", restoredDataSource?.id),
+    useQueryOptions: { enabled: needsColumns && isDatasetSource },
+  });
+
+  const [entityFieldConfigs] = EntityFieldConfigClient.useGetAll({
+    ...where("entity_config_id", "eq", restoredDataSource?.id),
+    useQueryOptions: { enabled: needsColumns && isEntityConfigSource },
+  });
+
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  // Decide once — on the very first render — whether we should hydrate from
+  // the URL. Using a ref prevents dispatched state changes from re-triggering
+  // the bail-out check mid-hydration (which would cause columns and viz config
+  // to never be restored after setDataSource fires).
+  const shouldHydrateRef = useRef<boolean | null>(null);
+  if (shouldHydrateRef.current === null) {
+    shouldHydrateRef.current =
+      urlSearchHasHydrateableExplorerKeys(urlState) &&
+      isDefaultExplorerState(state);
+  }
+
+  useEffect(() => {
+    if (isHydrated) {
+      return;
+    }
+
+    if (!shouldHydrateRef.current) {
+      setIsHydrated(true);
+      return;
+    }
+
+    if (
+      shouldDeferURLHydrationForStructuredLoading({
+        urlState,
+        restoredDataSource,
+        needsColumns,
+        datasetColumns,
+        entityFieldConfigs,
+      })
+    ) {
+      return;
+    }
+
+    if (restoreStructuredFromURL && restoredDataSource) {
+      dispatch.setDataSource(restoredDataSource);
+    }
+
+    if (
+      restoreStructuredFromURL &&
+      needsColumns &&
+      (datasetColumns ?? entityFieldConfigs)
+    ) {
+      const allQueryColumns = [
+        ...(datasetColumns ?? []).map((col) => {
+          return QueryColumns.makeFromDatasetColumn(col);
+        }),
+        ...(entityFieldConfigs ?? []).map((col) => {
+          return QueryColumns.makeFromEntityFieldConfig(col);
+        }),
+      ];
+
+      const restoredCols = (urlState.colNames ?? [])
+        .map((name) => {
+          return allQueryColumns.find((col) => {
+            return col.baseColumn.name === name;
+          });
+        })
+        .filter(isNonNullish);
+
+      if (restoredCols.length > 0) {
+        dispatch.setColumns(restoredCols);
+
+        if (urlState.aggregations) {
+          restoredCols.forEach((col) => {
+            const agg = urlState.aggregations?.[col.baseColumn.name];
+            if (agg) {
+              dispatch.setColumnAggregation({
+                columnId: col.id,
+                aggregation: agg,
+              });
+            }
+          });
+        }
+
+        if (urlState.orderByColName) {
+          const orderCol = restoredCols.find((col) => {
+            return col.baseColumn.name === urlState.orderByColName;
+          });
+          if (orderCol) {
+            dispatch.setOrderByColumn(orderCol.id);
+            if (urlState.orderDir) {
+              dispatch.setOrderByDirection(urlState.orderDir);
+            }
+          }
+        }
+      }
+    }
+
+    if (urlState.rawSQL) {
+      dispatch.setRawSQL(urlState.rawSQL);
+    }
+
+    if (urlState.openDataset) {
+      dispatch.setOpenDataset(urlState.openDataset);
+    }
+
+    // Restore viz config last — may overwrite the result of hydrateFromQuery
+    // that setColumns triggered above.
+    if (urlState.vizConfig) {
+      dispatch.setVizConfig(urlState.vizConfig);
+    }
+
+    setIsHydrated(true);
+    // Intentionally omitting `state` from deps: the "should hydrate?" decision
+    // is captured once via shouldHydrateRef so that mid-hydration state changes
+    // (from the dispatches above) do not re-trigger the bail-out check.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    isHydrated,
+    urlState,
+    restoredDataSource,
+    datasetColumns,
+    entityFieldConfigs,
+    needsColumns,
+    dispatch,
+  ]);
+
+  // Sync state → URL on every state change, after hydration completes.
+  const urlParams = useMemo(() => {
+    return serializeStateToURL(state);
+  }, [state]);
+  const lastSyncedRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!isHydrated) {
+      return;
+    }
+    const serialized = JSON.stringify(urlParams);
+    if (serialized === lastSyncedRef.current) {
+      return;
+    }
+    lastSyncedRef.current = serialized;
+    navigate({ search: urlParams, replace: true });
+  }, [isHydrated, urlParams, navigate]);
+}


### PR DESCRIPTION
### Summary

- Delivers additional Data Explorer chart types and per-viz settings (PTRCK-007 / PTRCK-008), with follow-up viz defaults and related model/UI adjustments (PTRCK-009).
- Adds URL-backed session state for the Data Explorer: parse, serialize, first-load hydration, and ongoing sync with `replace: true` (PTRCK-010).
- Treats `sql` as authoritative when present: structured URL fields are not written alongside it and are not restored from the URL, avoiding stale `ds` / column state vs manual SQL.
- Omits default table `vc` from the URL so Reset can clear search params without immediately re-adding `?vc=`.
- Fixes column selection after hydration by remapping on `baseColumn.id` (`remapColumnsByBaseId` + `QueryColumnMultiSelect` folder layout).

### Testing

- `pnpm lint`, `pnpm type-check`, `pnpm test` (or your usual frontend subset).
- Manual: shared URLs for structured query vs raw SQL only, Reset clears the bar, chart type + settings still behave, columns survive reload from a link.

### Tickets
(I can stop using my mostly fake ticket system if you want, lol.)

- PTRCK-007
- PTRCK-008
- PTRCK-009
- PTRCK-010