### PR TITLE
Replace Data Explorer Open modal with a tabbed drawer

### DIFF
--- a/packages/web/ui/src/Drawer/Drawer.module.css
+++ b/packages/web/ui/src/Drawer/Drawer.module.css
@@ -20,8 +20,8 @@
  * would otherwise escape the parent and span the whole window.
  */
 .scopedRoot {
-  position: absolute;
   inset: 0;
+  position: absolute;
 }
 
 .scopedInner {

--- a/packages/web/ui/src/Drawer/Drawer.module.css
+++ b/packages/web/ui/src/Drawer/Drawer.module.css
@@ -1,0 +1,33 @@
+.content {
+  background: var(--ava-surface-overlay);
+  border-left: 1px solid var(--ava-border-default);
+  box-shadow: var(--mantine-shadow-lg);
+}
+
+.header {
+  background: var(--ava-surface-overlay);
+  border-bottom: 1px solid var(--ava-border-default);
+}
+
+.body {
+  background: var(--ava-surface-overlay);
+}
+
+/**
+ * When `boundary` is set, the drawer is portaled into a parent element and
+ * must position itself relative to that parent rather than the viewport.
+ * Mantine's default `position: fixed` on `root`, `inner`, and `overlay`
+ * would otherwise escape the parent and span the whole window.
+ */
+.scopedRoot {
+  position: absolute;
+  inset: 0;
+}
+
+.scopedInner {
+  position: absolute;
+}
+
+.scopedOverlay {
+  position: absolute;
+}

--- a/packages/web/ui/src/Drawer/Drawer.tsx
+++ b/packages/web/ui/src/Drawer/Drawer.tsx
@@ -1,0 +1,50 @@
+import { Drawer as MantineDrawer } from "@mantine/core";
+import clsx from "clsx";
+import classes from "./Drawer.module.css";
+import type { DrawerProps as MantineDrawerProps } from "@mantine/core";
+
+type Props = MantineDrawerProps & {
+  /**
+   * Scope the drawer to render inside a specific element instead of the
+   * document body. Accepts a CSS selector string or HTMLElement. When set,
+   * the drawer's overlay and inner positioning switch from `fixed` to
+   * `absolute` so the drawer is constrained to the boundary element's box.
+   *
+   * Useful for constraining the drawer to the app's main layout area so it
+   * does not cover the side navbar or the chat panel (Aside).
+   */
+  boundary?: string | HTMLElement;
+};
+
+/**
+ * Avandar Drawer wrapper around Mantine's Drawer. Applies our theme tokens
+ * (surfaces, borders, shadows) and supports scoping the drawer to a parent
+ * element via the `boundary` prop.
+ */
+export function Drawer({
+  boundary,
+  classNames,
+  portalProps,
+  ...rest
+}: Props): JSX.Element {
+  const isScoped = boundary !== undefined;
+
+  const resolvedClassNames = {
+    root: clsx(isScoped && classes.scopedRoot, classNames?.root),
+    inner: clsx(isScoped && classes.scopedInner, classNames?.inner),
+    overlay: clsx(isScoped && classes.scopedOverlay, classNames?.overlay),
+    content: clsx(classes.content, classNames?.content),
+    header: clsx(classes.header, classNames?.header),
+    body: clsx(classes.body, classNames?.body),
+  };
+
+  return (
+    <MantineDrawer
+      classNames={resolvedClassNames}
+      portalProps={
+        isScoped ? { ...portalProps, target: boundary } : portalProps
+      }
+      {...rest}
+    />
+  );
+}

--- a/packages/web/ui/src/index.ts
+++ b/packages/web/ui/src/index.ts
@@ -10,6 +10,9 @@ export { Callout } from "./Callout/Callout";
 // Modal
 export { Modal } from "./Modal/Modal";
 
+// Drawer
+export { Drawer } from "./Drawer/Drawer";
+
 // buttons
 export { DangerousActionButton } from "./buttons/DangerousActionButton/DangerousActionButton";
 export { EditButton as EditIconButton } from "./buttons/EditButton";

--- a/src/components/AppShell/AppShell.tsx
+++ b/src/components/AppShell/AppShell.tsx
@@ -43,8 +43,8 @@ const ASIDE_DEFAULT_WIDTH = 380;
 
 /**
  * DOM id on the AppShell's main content area. Components that need to scope
- * an overlay (drawer, popover, etc.) to the main canvas — without covering
- * the side navbar or the chat panel Aside — can target this element.
+ * an overlay (drawer, popover, etc.) to the main canvas, without covering
+ * the side navbar or the chat panel Aside, can target this element.
  */
 export const APP_SHELL_MAIN_ID = "ava-app-shell-main";
 

--- a/src/components/AppShell/AppShell.tsx
+++ b/src/components/AppShell/AppShell.tsx
@@ -41,6 +41,13 @@ const NAVBAR_DEFAULT_WIDTH = 220;
 
 const ASIDE_DEFAULT_WIDTH = 380;
 
+/**
+ * DOM id on the AppShell's main content area. Components that need to scope
+ * an overlay (drawer, popover, etc.) to the main canvas — without covering
+ * the side navbar or the chat panel Aside — can target this element.
+ */
+export const APP_SHELL_MAIN_ID = "ava-app-shell-main";
+
 type Props = {
   /**
    * The main content of the app shell.
@@ -166,6 +173,7 @@ function AppShellComponent({
           />
         </MantineAppShell.Navbar>
         <MantineAppShell.Main
+          id={APP_SHELL_MAIN_ID}
           py="0"
           ml={-16}
           mr={-16}

--- a/src/views/DataExplorerApp/DataExplorerApp.tsx
+++ b/src/views/DataExplorerApp/DataExplorerApp.tsx
@@ -9,6 +9,7 @@ import {
   Stack,
   Text,
 } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
 import { modals } from "@mantine/modals";
 import {
   IconChevronDown,
@@ -29,7 +30,7 @@ import { useCurrentWorkspace } from "@/hooks/workspaces/useCurrentWorkspace";
 import { DataExplorerStateManager } from "@/views/DataExplorerApp/DataExplorerStateManager/DataExplorerStateManager";
 import { downloadRowsAsCSV } from "@/views/DataExplorerApp/downloadRowsAsCSV";
 import { GeneratedPromptBadge } from "@/views/DataExplorerApp/GeneratedPromptBadge/GeneratedPromptBadge";
-import { OpenDatasetModal } from "@/views/DataExplorerApp/OpenDatasetModal/OpenDatasetModal";
+import { OpenDatasetDrawer } from "@/views/DataExplorerApp/OpenDatasetDrawer/OpenDatasetDrawer";
 import { QueryForm } from "@/views/DataExplorerApp/QueryForm/QueryForm";
 import { SaveAsNewDatasetForm } from "@/views/DataExplorerApp/SaveAsNewDatasetForm/SaveAsNewDatasetForm";
 import { SaveToDashboardModal } from "@/views/DataExplorerApp/SaveToDashboardModal/SaveToDashboardModal";
@@ -50,6 +51,10 @@ type Props = {
 export function DataExplorerApp({ urlSearch, navigate }: Props): JSX.Element {
   const state = DataExplorerStateManager.useState();
   const dispatch = DataExplorerStateManager.useDispatch();
+  const [
+    isOpenDatasetDrawerOpen,
+    { open: openOpenDatasetDrawer, close: closeOpenDatasetDrawer },
+  ] = useDisclosure(false);
 
   useDataExplorerURLSync({ urlSearch, navigate });
 
@@ -195,20 +200,7 @@ export function DataExplorerApp({ urlSearch, navigate }: Props): JSX.Element {
               color="neutral"
               leftSection={<IconFolderOpen size={16} />}
               size="compact-sm"
-              onClick={() => {
-                modals.open({
-                  title: "Open Dataset",
-                  size: "lg",
-                  children: (
-                    <OpenDatasetModal
-                      onOpen={(info, rawSQL) => {
-                        dispatch.setRawSql(rawSQL);
-                        dispatch.setOpenDataset(info);
-                      }}
-                    />
-                  ),
-                });
-              }}
+              onClick={openOpenDatasetDrawer}
             >
               Open
             </Button>
@@ -226,20 +218,24 @@ export function DataExplorerApp({ urlSearch, navigate }: Props): JSX.Element {
               <Menu.Dropdown>
                 {state.openDataset ?
                   <>
-                    <Menu.Item
-                      disabled={!state.rawSQL || isSavingOver}
-                      onClick={() => {
-                        if (!state.rawSQL || !state.openDataset) {
-                          return;
-                        }
-                        saveOverDataset({
-                          id: state.openDataset.virtualDatasetId,
-                          data: { rawSQL: state.rawSQL },
-                        });
-                      }}
-                    >
-                      Save — {state.openDataset.name}
-                    </Menu.Item>
+                    {state.openDataset.virtualDatasetId ?
+                      <Menu.Item
+                        disabled={!state.rawSQL || isSavingOver}
+                        onClick={() => {
+                          const virtualDatasetId =
+                            state.openDataset?.virtualDatasetId;
+                          if (!state.rawSQL || !virtualDatasetId) {
+                            return;
+                          }
+                          saveOverDataset({
+                            id: virtualDatasetId,
+                            data: { rawSQL: state.rawSQL },
+                          });
+                        }}
+                      >
+                        Save — {state.openDataset.name}
+                      </Menu.Item>
+                    : null}
                     <Menu.Item
                       color="red"
                       disabled={isDeletingDataset}
@@ -372,6 +368,15 @@ export function DataExplorerApp({ urlSearch, navigate }: Props): JSX.Element {
           </Box>
         </Stack>
       </Flex>
+      <OpenDatasetDrawer
+        opened={isOpenDatasetDrawerOpen}
+        onClose={closeOpenDatasetDrawer}
+        onOpen={(info, rawSQL) => {
+          dispatch.setRawSql(rawSQL);
+          dispatch.setOpenDataset(info);
+          closeOpenDatasetDrawer();
+        }}
+      />
     </AppLayout>
   );
 }

--- a/src/views/DataExplorerApp/DataExplorerStateManager/dataExplorerAppState.ts
+++ b/src/views/DataExplorerApp/DataExplorerStateManager/dataExplorerAppState.ts
@@ -1,17 +1,21 @@
 import { StructuredQuery } from "$/models/queries/StructuredQuery/StructuredQuery";
 import type { DatasetId } from "$/models/datasets/Dataset/Dataset.types";
+import type { DatasetSource } from "$/models/datasets/DatasetSource/DatasetSource";
 import type { VirtualDatasetId } from "$/models/datasets/VirtualDataset/VirtualDataset.types";
 import type { PartialStructuredQuery } from "$/models/queries/StructuredQuery/StructuredQuery.types";
 import type { VizConfig } from "$/models/vizs/VizConfig/VizConfig.types";
 
 /**
  * Identifies the currently open saved dataset in the Data Explorer, if any.
- * Stored in state so the toolbar can offer "Save Over" and "Delete" actions.
+ * Stored in state so the toolbar can offer "Save Over" (virtual datasets
+ * only) and "Delete" actions. `virtualDatasetId` is only set when
+ * `sourceType === "virtual"`.
  */
 export type OpenDatasetInfo = {
   datasetId: DatasetId;
   name: string;
-  virtualDatasetId: VirtualDatasetId;
+  sourceType: DatasetSource.SourceType;
+  virtualDatasetId?: VirtualDatasetId;
 };
 
 export type DataExplorerAppState = {

--- a/src/views/DataExplorerApp/DataExplorerURLState.test.ts
+++ b/src/views/DataExplorerApp/DataExplorerURLState.test.ts
@@ -147,12 +147,44 @@ describe("parseURLSearch", () => {
     const od = JSON.stringify({
       did: "did-1",
       name: "My Dataset",
+      st: "virtual",
       vid: "vid-1",
     });
     const result = parseURLSearch({ od });
     expect(result.openDataset).toEqual({
       datasetId: "did-1",
       name: "My Dataset",
+      sourceType: "virtual",
+      virtualDatasetId: "vid-1",
+    });
+  });
+
+  it("parses a non-virtual openDataset without vid", () => {
+    const od = JSON.stringify({
+      did: "did-1",
+      name: "My Dataset",
+      st: "csv_file",
+    });
+    const result = parseURLSearch({ od });
+    expect(result.openDataset).toEqual({
+      datasetId: "did-1",
+      name: "My Dataset",
+      sourceType: "csv_file",
+      virtualDatasetId: undefined,
+    });
+  });
+
+  it("defaults legacy od (missing st) to sourceType=virtual", () => {
+    const od = JSON.stringify({
+      did: "did-1",
+      name: "My Dataset",
+      vid: "vid-1",
+    });
+    const result = parseURLSearch({ od });
+    expect(result.openDataset).toEqual({
+      datasetId: "did-1",
+      name: "My Dataset",
+      sourceType: "virtual",
       virtualDatasetId: "vid-1",
     });
   });
@@ -269,16 +301,38 @@ describe("serializeStateToURL", () => {
     expect(result.orderDir).toBeUndefined();
   });
 
-  it("serializes openDataset into the od param", () => {
+  it("serializes a virtual openDataset into the od param", () => {
     const openDataset: OpenDatasetInfo = {
       datasetId: "did-1" as DatasetId,
       name: "My Dataset",
+      sourceType: "virtual",
       virtualDatasetId: "vid-1" as VirtualDatasetId,
     };
     const result = serializeStateToURL(_makeState({ openDataset }));
     expect(result.od).toBeDefined();
     const parsed = JSON.parse(result.od!);
-    expect(parsed).toEqual({ did: "did-1", name: "My Dataset", vid: "vid-1" });
+    expect(parsed).toEqual({
+      did: "did-1",
+      name: "My Dataset",
+      st: "virtual",
+      vid: "vid-1",
+    });
+  });
+
+  it("serializes a non-virtual openDataset (no vid) into the od param", () => {
+    const openDataset: OpenDatasetInfo = {
+      datasetId: "did-1" as DatasetId,
+      name: "My Dataset",
+      sourceType: "csv_file",
+    };
+    const result = serializeStateToURL(_makeState({ openDataset }));
+    expect(result.od).toBeDefined();
+    const parsed = JSON.parse(result.od!);
+    expect(parsed).toEqual({
+      did: "did-1",
+      name: "My Dataset",
+      st: "csv_file",
+    });
   });
 });
 

--- a/src/views/DataExplorerApp/DataExplorerURLState.ts
+++ b/src/views/DataExplorerApp/DataExplorerURLState.ts
@@ -3,6 +3,7 @@ import type {
   DataExplorerAppState,
   OpenDatasetInfo,
 } from "@/views/DataExplorerApp/DataExplorerStateManager/dataExplorerAppState";
+import type { DatasetSource } from "$/models/datasets/DatasetSource/DatasetSource";
 import type { QueryAggregationType } from "$/models/queries/QueryAggregationType/QueryAggregationType";
 import type { OrderByDirection } from "$/models/queries/StructuredQuery/StructuredQuery.types";
 import type { VizConfig } from "$/models/vizs/VizConfig/VizConfig.types";
@@ -122,13 +123,22 @@ export function parseURLSearch(search: DataExplorerURLSearch): ParsedURLState {
       const raw = JSON.parse(search.od) as {
         did: string;
         name: string;
-        vid: string;
+        st?: string;
+        vid?: string;
       };
-      if (raw.did && raw.name && raw.vid) {
+      if (raw.did && raw.name) {
+        // Older URLs were emitted before non-virtual datasets could be
+        // opened; fall back to "virtual" so legacy links keep loading.
+        const sourceType = (raw.st ??
+          "virtual") as DatasetSource.SourceType;
         result.openDataset = {
           datasetId: raw.did as OpenDatasetInfo["datasetId"],
           name: raw.name,
-          virtualDatasetId: raw.vid as OpenDatasetInfo["virtualDatasetId"],
+          sourceType,
+          virtualDatasetId:
+            raw.vid ?
+              (raw.vid as NonNullable<OpenDatasetInfo["virtualDatasetId"]>)
+            : undefined,
         };
       }
     } catch {
@@ -208,11 +218,13 @@ export function serializeStateToURL(
   }
 
   if (state.openDataset) {
-    const { datasetId, name, virtualDatasetId } = state.openDataset;
+    const { datasetId, name, sourceType, virtualDatasetId } =
+      state.openDataset;
     params.od = JSON.stringify({
       did: datasetId,
       name,
-      vid: virtualDatasetId,
+      st: sourceType,
+      ...(virtualDatasetId ? { vid: virtualDatasetId } : {}),
     });
   }
 

--- a/src/views/DataExplorerApp/OpenDatasetDrawer/ImportDatasetView.tsx
+++ b/src/views/DataExplorerApp/OpenDatasetDrawer/ImportDatasetView.tsx
@@ -1,0 +1,22 @@
+import { DataImportTabs } from "@/views/DataManagerApp/DataImportView/DataImportTabs";
+import { useCanAddDataset } from "@/views/DataManagerApp/DataImportView/useCanAddDataset";
+import type { Dataset } from "$/models/datasets/Dataset/Dataset";
+
+type Props = {
+  onSaveSuccess: (dataset: Dataset.T) => void;
+};
+
+/**
+ * Renders the standard "Import data" tabs (Upload, Connectors, Open data)
+ * inside the Data Explorer's Open drawer. On successful save, the host
+ * drawer is notified instead of redirecting to the dataset detail page.
+ */
+export function ImportDatasetView({ onSaveSuccess }: Props): JSX.Element {
+  const isAddAllowed = useCanAddDataset();
+  return (
+    <DataImportTabs
+      isAddAllowed={isAddAllowed}
+      onSaveSuccess={onSaveSuccess}
+    />
+  );
+}

--- a/src/views/DataExplorerApp/OpenDatasetDrawer/OpenDatasetDrawer.tsx
+++ b/src/views/DataExplorerApp/OpenDatasetDrawer/OpenDatasetDrawer.tsx
@@ -1,0 +1,79 @@
+import { Title } from "@mantine/core";
+import { Drawer, Tabs } from "@ui";
+import { APP_SHELL_MAIN_ID } from "@/components/AppShell/AppShell";
+import { ImportDatasetView } from "@/views/DataExplorerApp/OpenDatasetDrawer/ImportDatasetView";
+import { SavedDatasetsView } from "@/views/DataExplorerApp/OpenDatasetDrawer/SavedDatasetsView";
+import type { OpenDatasetInfo } from "@/views/DataExplorerApp/DataExplorerStateManager/dataExplorerAppState";
+import type { Dataset } from "$/models/datasets/Dataset/Dataset";
+
+type Props = {
+  opened: boolean;
+  onClose: () => void;
+
+  /**
+   * Called when the user picks (or imports) a dataset. The drawer is
+   * responsible for the canvas-side state updates via this callback.
+   */
+  onOpen: (info: OpenDatasetInfo, rawSQL: string) => void;
+};
+
+function _quoteIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function _selectAllSQL(datasetId: string): string {
+  return `SELECT * FROM ${_quoteIdentifier(datasetId)} LIMIT 100`;
+}
+
+/**
+ * The Data Explorer's "Open" drawer. Toggles between a list of saved
+ * datasets and the dataset-import flow, and is scoped to the app's main
+ * layout so it does not cover the side navbar or chat panel Aside.
+ */
+export function OpenDatasetDrawer({
+  opened,
+  onClose,
+  onOpen,
+}: Props): JSX.Element {
+  const handleImportSaved = (dataset: Dataset.T) => {
+    onOpen(
+      {
+        datasetId: dataset.id,
+        name: dataset.name,
+        sourceType: dataset.sourceType,
+      },
+      _selectAllSQL(dataset.id),
+    );
+  };
+
+  const handleSavedOpen = (info: OpenDatasetInfo, rawSQL: string) => {
+    onOpen(info, rawSQL);
+  };
+
+  return (
+    <Drawer
+      opened={opened}
+      onClose={onClose}
+      boundary={`#${APP_SHELL_MAIN_ID}`}
+      position="right"
+      size="100%"
+      title={<Title order={4}>Open dataset</Title>}
+    >
+      <Tabs
+        tabIds={["saved", "import"] as const}
+        renderTabHeader={{
+          saved: "Saved datasets",
+          import: "Import dataset",
+        }}
+        renderTabPanel={{
+          saved: () => {
+            return <SavedDatasetsView onOpen={handleSavedOpen} />;
+          },
+          import: () => {
+            return <ImportDatasetView onSaveSuccess={handleImportSaved} />;
+          },
+        }}
+      />
+    </Drawer>
+  );
+}

--- a/src/views/DataExplorerApp/OpenDatasetDrawer/OpenDatasetDrawer.tsx
+++ b/src/views/DataExplorerApp/OpenDatasetDrawer/OpenDatasetDrawer.tsx
@@ -1,6 +1,7 @@
 import { Title } from "@mantine/core";
 import { Drawer, Tabs } from "@ui";
 import { APP_SHELL_MAIN_ID } from "@/components/AppShell/AppShell";
+import { buildSelectAllPreviewSQL } from "@/views/DataExplorerApp/OpenDatasetDrawer/datasetPreviewSQL";
 import { ImportDatasetView } from "@/views/DataExplorerApp/OpenDatasetDrawer/ImportDatasetView";
 import { SavedDatasetsView } from "@/views/DataExplorerApp/OpenDatasetDrawer/SavedDatasetsView";
 import type { OpenDatasetInfo } from "@/views/DataExplorerApp/DataExplorerStateManager/dataExplorerAppState";
@@ -17,14 +18,6 @@ type Props = {
   onOpen: (info: OpenDatasetInfo, rawSQL: string) => void;
 };
 
-function _quoteIdentifier(value: string): string {
-  return `"${value.replace(/"/g, '""')}"`;
-}
-
-function _selectAllSQL(datasetId: string): string {
-  return `SELECT * FROM ${_quoteIdentifier(datasetId)} LIMIT 100`;
-}
-
 /**
  * The Data Explorer's "Open" drawer. Toggles between a list of saved
  * datasets and the dataset-import flow, and is scoped to the app's main
@@ -35,19 +28,15 @@ export function OpenDatasetDrawer({
   onClose,
   onOpen,
 }: Props): JSX.Element {
-  const handleImportSaved = (dataset: Dataset.T) => {
+  const onImportSaved = (dataset: Dataset.T) => {
     onOpen(
       {
         datasetId: dataset.id,
         name: dataset.name,
         sourceType: dataset.sourceType,
       },
-      _selectAllSQL(dataset.id),
+      buildSelectAllPreviewSQL(dataset.id),
     );
-  };
-
-  const handleSavedOpen = (info: OpenDatasetInfo, rawSQL: string) => {
-    onOpen(info, rawSQL);
   };
 
   return (
@@ -67,10 +56,10 @@ export function OpenDatasetDrawer({
         }}
         renderTabPanel={{
           saved: () => {
-            return <SavedDatasetsView onOpen={handleSavedOpen} />;
+            return <SavedDatasetsView onOpen={onOpen} />;
           },
           import: () => {
-            return <ImportDatasetView onSaveSuccess={handleImportSaved} />;
+            return <ImportDatasetView onSaveSuccess={onImportSaved} />;
           },
         }}
       />

--- a/src/views/DataExplorerApp/OpenDatasetDrawer/SavedDatasetsView.tsx
+++ b/src/views/DataExplorerApp/OpenDatasetDrawer/SavedDatasetsView.tsx
@@ -1,6 +1,7 @@
 import { useMutation } from "@hooks";
 import {
   ActionIcon,
+  Badge,
   Button,
   Group,
   Stack,
@@ -19,18 +20,36 @@ import { VirtualDatasetClient } from "@/clients/datasets/source-datasets/Virtual
 import { useCurrentWorkspace } from "@/hooks/workspaces/useCurrentWorkspace";
 import type { OpenDatasetInfo } from "@/views/DataExplorerApp/DataExplorerStateManager/dataExplorerAppState";
 import type { Dataset } from "$/models/datasets/Dataset/Dataset";
+import type { DatasetSource } from "$/models/datasets/DatasetSource/DatasetSource";
 import type { VirtualDataset } from "$/models/datasets/VirtualDataset/VirtualDataset";
 
 type Props = {
   onOpen: (info: OpenDatasetInfo, rawSQL: string) => void;
 };
 
+const SOURCE_TYPE_LABEL: Record<DatasetSource.SourceType, string> = {
+  csv_file: "CSV",
+  xlsx_file: "Excel",
+  google_sheets: "Google Sheets",
+  open_data: "Open data",
+  virtual: "Derived",
+};
+
+function _quoteIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function _selectAllSQL(datasetId: string): string {
+  return `SELECT * FROM ${_quoteIdentifier(datasetId)} LIMIT 100`;
+}
+
 /**
- * Modal body for browsing and opening saved (virtual) datasets in the
- * Data Explorer. Only datasets created via AI query ("virtual" source type)
- * have a raw SQL query that can be loaded back into the explorer.
+ * Lists every saved dataset in the workspace. Opening a derived (virtual)
+ * dataset runs its stored SQL; opening any other dataset runs
+ * `SELECT * FROM "<datasetId>" LIMIT 100` so the user lands on the dataset's
+ * raw rows in the Data Explorer canvas.
  */
-export function OpenDatasetModal({ onOpen }: Props): JSX.Element {
+export function SavedDatasetsView({ onOpen }: Props): JSX.Element {
   const workspace = useCurrentWorkspace();
   const [search, setSearch] = useState("");
   const [debouncedSearch] = useDebouncedValue(search, 200);
@@ -40,11 +59,7 @@ export function OpenDatasetModal({ onOpen }: Props): JSX.Element {
     useQueryOptions: { enabled: true },
   });
 
-  const virtualDatasets = (datasets ?? []).filter((d) => {
-    return d.sourceType === "virtual";
-  });
-
-  const filtered = virtualDatasets.filter((d) => {
+  const filtered = (datasets ?? []).filter((d) => {
     if (!debouncedSearch) {
       return true;
     }
@@ -82,16 +97,31 @@ export function OpenDatasetModal({ onOpen }: Props): JSX.Element {
         {
           datasetId: dataset.id,
           name: dataset.name,
+          sourceType: "virtual",
           virtualDatasetId: virtualDataset.id,
         },
         virtualDataset.rawSQL,
       );
-      modals.closeAll();
     },
     onError: (error: Error) => {
       notifyError(error.message);
     },
   });
+
+  const onOpenClick = (dataset: Dataset.T) => {
+    if (dataset.sourceType === "virtual") {
+      loadVirtualDataset(dataset);
+      return;
+    }
+    onOpen(
+      {
+        datasetId: dataset.id,
+        name: dataset.name,
+        sourceType: dataset.sourceType,
+      },
+      _selectAllSQL(dataset.id),
+    );
+  };
 
   const onDeleteClick = (dataset: Dataset.T) => {
     modals.openConfirmModal({
@@ -135,7 +165,8 @@ export function OpenDatasetModal({ onOpen }: Props): JSX.Element {
           <Table.Thead>
             <Table.Tr>
               <Table.Th>Name</Table.Th>
-              <Table.Th w={100} />
+              <Table.Th w={120}>Type</Table.Th>
+              <Table.Th w={140} />
             </Table.Tr>
           </Table.Thead>
           <Table.Tbody>
@@ -144,13 +175,19 @@ export function OpenDatasetModal({ onOpen }: Props): JSX.Element {
                 <Table.Tr key={dataset.id}>
                   <Table.Td>{dataset.name}</Table.Td>
                   <Table.Td>
+                    <Badge color="neutral" variant="light" size="sm">
+                      {SOURCE_TYPE_LABEL[dataset.sourceType] ??
+                        dataset.sourceType}
+                    </Badge>
+                  </Table.Td>
+                  <Table.Td>
                     <Group gap="xs" justify="flex-end">
                       <Button
                         size="compact-xs"
                         variant="light"
                         disabled={isBusy}
                         onClick={() => {
-                          loadVirtualDataset(dataset);
+                          onOpenClick(dataset);
                         }}
                       >
                         Open

--- a/src/views/DataExplorerApp/OpenDatasetDrawer/SavedDatasetsView.tsx
+++ b/src/views/DataExplorerApp/OpenDatasetDrawer/SavedDatasetsView.tsx
@@ -15,9 +15,11 @@ import { IconSearch, IconTrash } from "@tabler/icons-react";
 import { notifyError, notifySuccess } from "@ui";
 import { where } from "@utils";
 import { useState } from "react";
+import { match } from "ts-pattern";
 import { DatasetClient } from "@/clients/datasets/DatasetClient";
 import { VirtualDatasetClient } from "@/clients/datasets/source-datasets/VirtualDatasetClient";
 import { useCurrentWorkspace } from "@/hooks/workspaces/useCurrentWorkspace";
+import { buildSelectAllPreviewSQL } from "@/views/DataExplorerApp/OpenDatasetDrawer/datasetPreviewSQL";
 import type { OpenDatasetInfo } from "@/views/DataExplorerApp/DataExplorerStateManager/dataExplorerAppState";
 import type { Dataset } from "$/models/datasets/Dataset/Dataset";
 import type { DatasetSource } from "$/models/datasets/DatasetSource/DatasetSource";
@@ -35,14 +37,6 @@ const SOURCE_TYPE_LABEL: Record<DatasetSource.SourceType, string> = {
   virtual: "Derived",
 };
 
-function _quoteIdentifier(value: string): string {
-  return `"${value.replace(/"/g, '""')}"`;
-}
-
-function _selectAllSQL(datasetId: string): string {
-  return `SELECT * FROM ${_quoteIdentifier(datasetId)} LIMIT 100`;
-}
-
 /**
  * Lists every saved dataset in the workspace. Opening a derived (virtual)
  * dataset runs its stored SQL; opening any other dataset runs
@@ -59,11 +53,11 @@ export function SavedDatasetsView({ onOpen }: Props): JSX.Element {
     useQueryOptions: { enabled: true },
   });
 
-  const filtered = (datasets ?? []).filter((d) => {
+  const filtered = (datasets ?? []).filter((dataset) => {
     if (!debouncedSearch) {
       return true;
     }
-    return d.name.toLowerCase().includes(debouncedSearch.toLowerCase());
+    return dataset.name.toLowerCase().includes(debouncedSearch.toLowerCase());
   });
 
   const [deleteDataset, isDeletingDataset] = DatasetClient.useFullDelete({
@@ -108,19 +102,26 @@ export function SavedDatasetsView({ onOpen }: Props): JSX.Element {
     },
   });
 
-  const onOpenClick = (dataset: Dataset.T) => {
-    if (dataset.sourceType === "virtual") {
-      loadVirtualDataset(dataset);
-      return;
-    }
+  const openAsRawPreview = (dataset: Dataset.T) => {
     onOpen(
       {
         datasetId: dataset.id,
         name: dataset.name,
         sourceType: dataset.sourceType,
       },
-      _selectAllSQL(dataset.id),
+      buildSelectAllPreviewSQL(dataset.id),
     );
+  };
+
+  const onOpenClick = (dataset: Dataset.T) => {
+    match(dataset.sourceType)
+      .with("virtual", () => {
+        loadVirtualDataset(dataset);
+      })
+      .with("csv_file", "xlsx_file", "google_sheets", "open_data", () => {
+        openAsRawPreview(dataset);
+      })
+      .exhaustive();
   };
 
   const onDeleteClick = (dataset: Dataset.T) => {

--- a/src/views/DataExplorerApp/OpenDatasetDrawer/datasetPreviewSQL.ts
+++ b/src/views/DataExplorerApp/OpenDatasetDrawer/datasetPreviewSQL.ts
@@ -1,0 +1,16 @@
+/**
+ * Builds a `SELECT * FROM "<datasetId>" LIMIT 100` query used by the Data
+ * Explorer when opening a non-derived dataset (CSV, XLSX, Google Sheets,
+ * open data). Quotes the identifier so dataset UUIDs with dashes and
+ * non-identifier characters work as DuckDB table names.
+ */
+export function buildSelectAllPreviewSQL(datasetId: string): string {
+  return `SELECT * FROM ${quoteIdentifier(datasetId)} LIMIT 100`;
+}
+
+/**
+ * Quotes a DuckDB SQL identifier, escaping any embedded double quotes.
+ */
+export function quoteIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}

--- a/src/views/DataExplorerApp/dataExplorerURLHydration.test.ts
+++ b/src/views/DataExplorerApp/dataExplorerURLHydration.test.ts
@@ -47,6 +47,7 @@ describe("urlSearchHasHydrateableExplorerKeys", () => {
     const openDataset = {
       datasetId: "d",
       name: "n",
+      sourceType: "virtual",
       virtualDatasetId: "v",
     } as OpenDatasetInfo;
     expect(urlSearchHasHydrateableExplorerKeys(_parsed({ openDataset }))).toBe(

--- a/src/views/DataManagerApp/DataImportView/DataImportTabs.tsx
+++ b/src/views/DataManagerApp/DataImportView/DataImportTabs.tsx
@@ -1,0 +1,55 @@
+import { Tabs } from "@ui";
+import { GoogleSheetsImportView } from "@/views/DataManagerApp/DataImportView/GoogleSheetsImportView/GoogleSheetsImportView";
+import { ManualUploadView } from "@/views/DataManagerApp/DataImportView/ManualUploadView/ManualUploadView";
+import { OpenDataCatalogView } from "@/views/DataManagerApp/DataImportView/OpenDataCatalogView/OpenDataCatalogView";
+import type { Dataset } from "$/models/datasets/Dataset/Dataset";
+
+type Props = {
+  isAddAllowed: boolean;
+
+  /**
+   * When set, the import sub-views skip their default post-save navigation
+   * and call this callback with the newly saved dataset instead.
+   */
+  onSaveSuccess?: (dataset: Dataset.T) => void;
+};
+
+/**
+ * The three import flows (manual upload, connectors, open data catalog)
+ * wrapped in tabs. Shared between the standalone DataImportView page and
+ * the Data Explorer's "Open" drawer.
+ */
+export function DataImportTabs({
+  isAddAllowed,
+  onSaveSuccess,
+}: Props): JSX.Element {
+  return (
+    <Tabs
+      tabIds={["upload-view", "connectors-view", "open-data-catalog"] as const}
+      renderTabHeader={{
+        "upload-view": "Upload",
+        "connectors-view": "Connectors",
+        "open-data-catalog": "Open data",
+      }}
+      renderTabPanel={{
+        "upload-view": () => {
+          return <ManualUploadView py="md" onSaveSuccess={onSaveSuccess} />;
+        },
+        "connectors-view": () => {
+          return (
+            <GoogleSheetsImportView py="md" onSaveSuccess={onSaveSuccess} />
+          );
+        },
+        "open-data-catalog": () => {
+          return (
+            <OpenDataCatalogView
+              isAddAllowed={isAddAllowed}
+              onSaveSuccess={onSaveSuccess}
+              py="md"
+            />
+          );
+        },
+      }}
+    />
+  );
+}

--- a/src/views/DataManagerApp/DataImportView/DataImportView.tsx
+++ b/src/views/DataManagerApp/DataImportView/DataImportView.tsx
@@ -1,84 +1,20 @@
-import { useQuery } from "@hooks";
 import { Container, Stack, Title } from "@mantine/core";
-import { Tabs, Paper  } from "@ui";
-import { where } from "@utils";
-import { SubscriptionModule } from "$/models/Subscription/SubscriptionModule";
-import { APIClient } from "@/clients/APIClient";
-import { DatasetClient } from "@/clients/datasets/DatasetClient";
+import { Paper } from "@ui";
 import { useCurrentWorkspace } from "@/hooks/workspaces/useCurrentWorkspace";
+import { DataImportTabs } from "@/views/DataManagerApp/DataImportView/DataImportTabs";
 import { DatasetLimitReachedModal } from "@/views/DataManagerApp/DataImportView/DatasetLimitReachedModal/DatasetLimitReachedModal";
-import { GoogleSheetsImportView } from "@/views/DataManagerApp/DataImportView/GoogleSheetsImportView/GoogleSheetsImportView";
-import { ManualUploadView } from "@/views/DataManagerApp/DataImportView/ManualUploadView/ManualUploadView";
-import { OpenDataCatalogView } from "@/views/DataManagerApp/DataImportView/OpenDataCatalogView/OpenDataCatalogView";
+import { useCanAddDataset } from "@/views/DataManagerApp/DataImportView/useCanAddDataset";
 
 export function DataImportView(): JSX.Element {
   const workspace = useCurrentWorkspace();
-
-  const [allDatasets = []] = DatasetClient.useGetAll(
-    where("workspace_id", "eq", workspace.id),
-  );
-
-  // we should check if the user is allowed to add more datasets based on their
-  // subscription plan
-  const [canAddDatasets] = useQuery({
-    queryKey: [
-      "subscriptionPermission",
-      workspace.subscription?.polarSubscriptionId,
-      "permissions",
-      "can_add_datasets",
-    ],
-    queryFn: async () => {
-      return await APIClient.get({
-        route: "subscriptions/:subscriptionId/permissions/:permissionType",
-        pathParams: {
-          subscriptionId: workspace.subscription?.polarSubscriptionId ?? "",
-          permissionType: "can_add_datasets",
-        },
-      });
-    },
-    enabled: !!workspace.subscription?.polarSubscriptionId,
-  });
-
-  const isAddAllowed =
-    canAddDatasets !== undefined ?
-      canAddDatasets.allowed
-      // if the permissions check in the backend isn't complete yet, then we do
-      // an eager frontend check. But this may be inaccurate if the user does
-      // not have permissions to view all workspace datasets, so the count will
-      // not be the real workspace dataset count.
-    : SubscriptionModule.canAddDatasets({
-        subscription: workspace.subscription,
-        numDatasetsInWorkspace: allDatasets.length,
-      });
+  const isAddAllowed = useCanAddDataset();
 
   return (
     <Container pt="xxl">
       <Paper>
         <Stack>
           <Title order={2}>Import data</Title>
-          <Tabs
-            tabIds={
-              ["upload-view", "connectors-view", "open-data-catalog"] as const
-            }
-            renderTabHeader={{
-              "upload-view": "Upload",
-              "connectors-view": "Connectors",
-              "open-data-catalog": "Open data",
-            }}
-            renderTabPanel={{
-              "upload-view": () => {
-                return <ManualUploadView py="md" />;
-              },
-              "connectors-view": () => {
-                return <GoogleSheetsImportView py="md" />;
-              },
-              "open-data-catalog": () => {
-                return (
-                  <OpenDataCatalogView isAddAllowed={isAddAllowed} py="md" />
-                );
-              },
-            }}
-          />
+          <DataImportTabs isAddAllowed={isAddAllowed} />
         </Stack>
       </Paper>
 

--- a/src/views/DataManagerApp/DataImportView/DatasetImportForm/DatasetImportForm.tsx
+++ b/src/views/DataManagerApp/DataImportView/DatasetImportForm/DatasetImportForm.tsx
@@ -143,6 +143,13 @@ type Props = {
 
   /** The parse options for the dataset. This is a controlled component. */
   parseOptions: FileParseOptions;
+
+  /**
+   * If set, this callback is invoked with the saved dataset instead of
+   * navigating to the dataset detail page on success. Forwarded to
+   * `useSaveDataset`.
+   */
+  onSaveSuccess?: (dataset: Dataset.T) => void;
 };
 
 /**
@@ -159,6 +166,7 @@ export function DatasetImportForm({
   onRequestDataReparse,
   isProcessing = false,
   dataSourceMetadata,
+  onSaveSuccess,
 }: Props): JSX.Element {
   const nameInputRef = useRef<HTMLInputElement>(null);
   const descriptionInputRef = useRef<HTMLInputElement>(null);
@@ -182,7 +190,7 @@ export function DatasetImportForm({
     },
   });
 
-  const [saveDataset, isSavePending] = useSaveDataset();
+  const [saveDataset, isSavePending] = useSaveDataset({ onSaveSuccess });
 
   const previewRows = useMemo(() => {
     return rows.slice(0, AppConfig.dataManagerApp.maxPreviewRows);

--- a/src/views/DataManagerApp/DataImportView/DatasetImportForm/useSaveDataset/useSaveDataset.ts
+++ b/src/views/DataManagerApp/DataImportView/DatasetImportForm/useSaveDataset/useSaveDataset.ts
@@ -57,12 +57,25 @@ function _duckDbColumnsToImportedColumns(
   });
 }
 
-export function useSaveDataset(): UseMutationResultTuple<
+type UseSaveDatasetOptions = {
+  /**
+   * If set, the default redirect to the dataset view is skipped and this
+   * callback is invoked with the saved dataset instead. Use this when the
+   * caller wants to handle the post-save action itself (e.g. opening the
+   * dataset in the Data Explorer instead of navigating to its detail page).
+   */
+  onSaveSuccess?: (dataset: Dataset.T) => void;
+};
+
+export function useSaveDataset(
+  options: UseSaveDatasetOptions = {},
+): UseMutationResultTuple<
   Dataset.T,
   DatasetImportFormValues & DataSourceMetadata
 > {
   const navigate = useNavigate();
   const workspace = useCurrentWorkspace();
+  const { onSaveSuccess } = options;
 
   return useMutation({
     queryToInvalidate: DatasetClient.QueryKeys.getAll(),
@@ -185,6 +198,11 @@ export function useSaveDataset(): UseMutationResultTuple<
             `Unsupported dataset source type: ${params.sourceType}`,
           );
         });
+
+      if (onSaveSuccess) {
+        onSaveSuccess(savedDataset);
+        return;
+      }
 
       navigate(
         AppLinks.dataManagerDatasetView({

--- a/src/views/DataManagerApp/DataImportView/GoogleSheetsImportView/GoogleSheetsImportView.tsx
+++ b/src/views/DataManagerApp/DataImportView/GoogleSheetsImportView/GoogleSheetsImportView.tsx
@@ -49,9 +49,18 @@ type GoogleSheetsRawData = {
   spreadsheetName: string;
 };
 
-type Props = BoxProps;
+type Props = BoxProps & {
+  /**
+   * When set, this callback is invoked with the newly saved dataset instead
+   * of the default navigation to the dataset detail page.
+   */
+  onSaveSuccess?: (dataset: Dataset.T) => void;
+};
 
-export function GoogleSheetsImportView(props: Props): JSX.Element {
+export function GoogleSheetsImportView({
+  onSaveSuccess,
+  ...props
+}: Props): JSX.Element {
   const user = useCurrentUser();
   const workspace = useCurrentWorkspace();
   const [selectedDocument, setSelectedDocument] = useState<
@@ -321,6 +330,7 @@ export function GoogleSheetsImportView(props: Props): JSX.Element {
               dataSourceMetadata.datasetLoadResult.spreadsheetName
             }
             isProcessing={isFetchingGoogleSheet || isLoadingGoogleSheet}
+            onSaveSuccess={onSaveSuccess}
             onDataSourceMetadataChange={(metadata) => {
               setDataSourceMetadata(metadata as GoogleSheetsDataSourceMetadata);
             }}

--- a/src/views/DataManagerApp/DataImportView/ManualUploadView/ManualUploadView.tsx
+++ b/src/views/DataManagerApp/DataImportView/ManualUploadView/ManualUploadView.tsx
@@ -14,7 +14,13 @@ import { ManualUploadDropzone } from "./ManualUploadDropzone";
 import type { ParseManualFileOptions } from "./useLoadManualUploadFile/useLoadManualUploadFile";
 import type { Dataset } from "$/models/datasets/Dataset/Dataset";
 
-type Props = BoxProps;
+type Props = BoxProps & {
+  /**
+   * When set, this callback is invoked with the newly saved dataset instead
+   * of the default navigation to the dataset detail page.
+   */
+  onSaveSuccess?: (dataset: Dataset.T) => void;
+};
 
 function _fileMimeTypeToSourceType(file: File): "csv_file" | "xlsx_file" {
   const lowerFileName = file.name.toLowerCase();
@@ -42,7 +48,10 @@ function _fileMimeTypeToSourceType(file: File): "csv_file" | "xlsx_file" {
   throw new Error(`Unsupported file type: ${file.type}`);
 }
 
-export function ManualUploadView(props: Props): JSX.Element {
+export function ManualUploadView({
+  onSaveSuccess,
+  ...props
+}: Props): JSX.Element {
   const [uploadedFile, setUploadedFile] = useState<File | undefined>();
   const {
     dataSourceMetadata,
@@ -101,6 +110,7 @@ export function ManualUploadView(props: Props): JSX.Element {
           rows={previewRows}
           dataSourceMetadata={dataSourceMetadata}
           parseOptions={parseOptions}
+          onSaveSuccess={onSaveSuccess}
           onDataSourceMetadataChange={(metadata) => {
             setDataSourceMetadata(metadata as ManualUploadDataSourceMetadata);
           }}

--- a/src/views/DataManagerApp/DataImportView/OpenDataCatalogView/OpenDataCatalogView.tsx
+++ b/src/views/DataManagerApp/DataImportView/OpenDataCatalogView/OpenDataCatalogView.tsx
@@ -30,10 +30,17 @@ import { resolveOpenDataDatasetColumnInputs } from "@/views/DataManagerApp/DataI
 import { OpenDataCatalogEntryDetail } from "@/views/DataManagerApp/DataImportView/OpenDataCatalogView/OpenDataCatalogEntryDetail";
 import { OpenDataCatalogEntryList } from "@/views/DataManagerApp/DataImportView/OpenDataCatalogView/OpenDataCatalogEntryList";
 import type { OpenDataCatalogEntryRead } from "$/models/catalog-entries/OpenDataCatalogEntry/OpenDataCatalogEntry.types";
+import type { Dataset } from "$/models/datasets/Dataset/Dataset";
 
 type Props = BoxProps & {
   /** When false, the add action is disabled (subscription limits). */
   isAddAllowed: boolean;
+
+  /**
+   * When set, this callback is invoked with the newly saved dataset after
+   * a successful catalog-entry import.
+   */
+  onSaveSuccess?: (dataset: Dataset.T) => void;
 };
 
 /**
@@ -42,6 +49,7 @@ type Props = BoxProps & {
  */
 export function OpenDataCatalogView({
   isAddAllowed,
+  onSaveSuccess,
   ...boxProps
 }: Props): JSX.Element {
   const workspace = useCurrentWorkspace();
@@ -101,6 +109,7 @@ export function OpenDataCatalogView({
           title: "Dataset added",
           message: `"${dataset.name}" is now in your workspace.`,
         });
+        onSaveSuccess?.(dataset);
       },
       queriesToInvalidate: [DatasetClient.QueryKeys.getAll()],
     });

--- a/src/views/DataManagerApp/DataImportView/useCanAddDataset.ts
+++ b/src/views/DataManagerApp/DataImportView/useCanAddDataset.ts
@@ -1,0 +1,51 @@
+import { useQuery } from "@hooks";
+import { where } from "@utils";
+import { SubscriptionModule } from "$/models/Subscription/SubscriptionModule";
+import { APIClient } from "@/clients/APIClient";
+import { DatasetClient } from "@/clients/datasets/DatasetClient";
+import { useCurrentWorkspace } from "@/hooks/workspaces/useCurrentWorkspace";
+
+/**
+ * Returns whether the current workspace is allowed to add another dataset
+ * given its subscription plan. Uses the backend permission check when the
+ * subscription is known, and falls back to an optimistic frontend check
+ * based on the cached dataset list.
+ */
+export function useCanAddDataset(): boolean {
+  const workspace = useCurrentWorkspace();
+  const [allDatasets = []] = DatasetClient.useGetAll(
+    where("workspace_id", "eq", workspace.id),
+  );
+
+  const [canAddDatasets] = useQuery({
+    queryKey: [
+      "subscriptionPermission",
+      workspace.subscription?.polarSubscriptionId,
+      "permissions",
+      "can_add_datasets",
+    ],
+    queryFn: async () => {
+      return await APIClient.get({
+        route: "subscriptions/:subscriptionId/permissions/:permissionType",
+        pathParams: {
+          subscriptionId: workspace.subscription?.polarSubscriptionId ?? "",
+          permissionType: "can_add_datasets",
+        },
+      });
+    },
+    enabled: !!workspace.subscription?.polarSubscriptionId,
+  });
+
+  if (canAddDatasets !== undefined) {
+    return canAddDatasets.allowed;
+  }
+
+  // If the permissions check in the backend isn't complete yet, we do
+  // an eager frontend check. This may be inaccurate if the user does not
+  // have permissions to view all workspace datasets, so the count will
+  // not be the real workspace dataset count.
+  return SubscriptionModule.canAddDatasets({
+    subscription: workspace.subscription,
+    numDatasetsInWorkspace: allDatasets.length,
+  });
+}


### PR DESCRIPTION
The toolbar "Open" action now opens a drawer scoped to the app's main
layout (so it does not cover the side navbar or chat panel Aside) with
two tabs:

- Saved datasets: lists every workspace dataset, not just derived ones.
  Opening a derived dataset runs its stored SQL; any other dataset opens
  with `SELECT * FROM "<datasetId>" LIMIT 100`.
- Import dataset: reuses the existing Upload / Connectors / Open data
  import flows. On save, the new dataset is opened in the canvas
  instead of redirecting to the dataset detail view.

Also adds a Drawer wrapper to @avandar/ui that applies the theme
tokens (surface-overlay, border-default, shadow-lg) and supports a
`boundary` prop for scoping the drawer to a parent element via
absolute positioning.