### PR TITLE
Add typing indicator to chat assistant bubble

### DIFF
--- a/src/components/ChatPanel/ChatThread/AssistantMessage/AssistantMessage.tsx
+++ b/src/components/ChatPanel/ChatThread/AssistantMessage/AssistantMessage.tsx
@@ -1,4 +1,5 @@
 import { MessagePrimitive } from "@assistant-ui/react";
+import { Loader } from "@mantine/core";
 import { TextPart } from "@/components/ChatPanel/ChatThread/TextPart/TextPart";
 import css from "../ChatThread.module.css";
 
@@ -6,6 +7,14 @@ export function AssistantMessage(): JSX.Element {
   return (
     <MessagePrimitive.Root className={css.assistantRow}>
       <div className={css.assistantBubble}>
+        <MessagePrimitive.If hasContent={false}>
+          <Loader
+            type="dots"
+            size="sm"
+            color="neutral.5"
+            aria-label="Assistant is typing"
+          />
+        </MessagePrimitive.If>
         <MessagePrimitive.Parts components={{ Text: TextPart }} />
       </div>
     </MessagePrimitive.Root>


### PR DESCRIPTION
Renders Mantine's animated dots Loader inside the empty assistant
bubble while waiting for the response, giving users immediate feedback
that a reply is being generated.