### PR TITLE
Visually disable chat panel when chat is unavailable

### DIFF
--- a/src/components/ChatPanel/ChatPanel/ChatPanel.module.css
+++ b/src/components/ChatPanel/ChatPanel/ChatPanel.module.css
@@ -2,6 +2,10 @@
   border-left: 1px solid var(--ava-border-default);
 }
 
+.shellDisabled {
+  background-color: rgb(0 0 0 / 6%);
+}
+
 .header {
   border-bottom: 1px solid var(--ava-border-default);
 }

--- a/src/components/ChatPanel/ChatPanel/ChatPanel.tsx
+++ b/src/components/ChatPanel/ChatPanel/ChatPanel.tsx
@@ -5,6 +5,7 @@ import { Tooltip } from "@ui";
 import { ChatPanelStateManager } from "@/components/ChatPanel/ChatPanelStateManager/ChatPanelStateManager";
 import { ChatThread } from "@/components/ChatPanel/ChatThread/ChatThread";
 import { useAvandarChatRuntime } from "@/components/ChatPanel/useAvandarChatRuntime";
+import { useChatPageContext } from "@/components/ChatPanel/useChatPageContext";
 import css from "./ChatPanel.module.css";
 
 /**
@@ -17,10 +18,18 @@ import css from "./ChatPanel.module.css";
 export function ChatPanel(): JSX.Element {
   const dispatch = ChatPanelStateManager.useDispatch();
   const runtime = useAvandarChatRuntime();
+  const context = useChatPageContext();
+  const disabled = context.app !== "data-explorer";
 
   return (
     <Box h="100%" py="xs" pr="xs">
-      <Stack h="100%" bg="white" bdrs="md" className={css.shell} gap={0}>
+      <Stack
+        h="100%"
+        bg={disabled ? undefined : "white"}
+        bdrs="md"
+        className={`${css.shell}${disabled ? ` ${css.shellDisabled}` : ""}`}
+        gap={0}
+      >
         <Group px="md" py="sm" justify="space-between" className={css.header}>
           <Group gap="xs">
             <IconSparkles size={16} color="var(--mantine-color-primary-6)" />

--- a/src/components/ChatPanel/ChatPanel/ChatPanel.tsx
+++ b/src/components/ChatPanel/ChatPanel/ChatPanel.tsx
@@ -2,6 +2,7 @@ import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import { ActionIcon, Box, Group, Stack, Text } from "@mantine/core";
 import { IconSparkles, IconX } from "@tabler/icons-react";
 import { Tooltip } from "@ui";
+import clsx from "clsx";
 import { ChatPanelStateManager } from "@/components/ChatPanel/ChatPanelStateManager/ChatPanelStateManager";
 import { ChatThread } from "@/components/ChatPanel/ChatThread/ChatThread";
 import { useAvandarChatRuntime } from "@/components/ChatPanel/useAvandarChatRuntime";
@@ -27,7 +28,7 @@ export function ChatPanel(): JSX.Element {
         h="100%"
         bg={disabled ? undefined : "white"}
         bdrs="md"
-        className={`${css.shell}${disabled ? ` ${css.shellDisabled}` : ""}`}
+        className={clsx(css.shell, disabled && css.shellDisabled)}
         gap={0}
       >
         <Group px="md" py="sm" justify="space-between" className={css.header}>

--- a/src/components/ChatPanel/ChatThread/ChatThread.module.css
+++ b/src/components/ChatPanel/ChatThread/ChatThread.module.css
@@ -90,6 +90,10 @@
   border-color: var(--ava-border-focus);
 }
 
+.composerDisabled {
+  background: transparent;
+}
+
 .composerInput {
   background: transparent;
   border: 0;
@@ -104,6 +108,15 @@
 }
 
 .composerInput::placeholder {
+  color: var(--mantine-color-neutral-5);
+}
+
+.composerInput:disabled {
+  color: var(--mantine-color-neutral-5);
+  cursor: not-allowed;
+}
+
+.composerInput:disabled::placeholder {
   color: var(--mantine-color-neutral-5);
 }
 

--- a/src/components/ChatPanel/ChatThread/Composer/Composer.tsx
+++ b/src/components/ChatPanel/ChatThread/Composer/Composer.tsx
@@ -10,7 +10,9 @@ export function Composer(): JSX.Element {
 
   return (
     <div className={css.composerContainer}>
-      <ComposerPrimitive.Root className={css.composer}>
+      <ComposerPrimitive.Root
+        className={`${css.composer}${disabled ? ` ${css.composerDisabled}` : ""}`}
+      >
         <ComposerPrimitive.Input
           className={css.composerInput}
           placeholder={

--- a/src/components/ChatPanel/ChatThread/Composer/Composer.tsx
+++ b/src/components/ChatPanel/ChatThread/Composer/Composer.tsx
@@ -1,6 +1,7 @@
 import { ComposerPrimitive } from "@assistant-ui/react";
 import { ActionIcon } from "@mantine/core";
 import { IconArrowUp } from "@tabler/icons-react";
+import clsx from "clsx";
 import { useChatPageContext } from "@/components/ChatPanel/useChatPageContext";
 import css from "../ChatThread.module.css";
 
@@ -11,7 +12,7 @@ export function Composer(): JSX.Element {
   return (
     <div className={css.composerContainer}>
       <ComposerPrimitive.Root
-        className={`${css.composer}${disabled ? ` ${css.composerDisabled}` : ""}`}
+        className={clsx(css.composer, disabled && css.composerDisabled)}
       >
         <ComposerPrimitive.Input
           className={css.composerInput}


### PR DESCRIPTION
Tints the panel background and the composer text so it's obvious the
chat input can't be used in apps where chat isn't enabled (everything
outside Data Explorer for now), instead of only the placeholder copy
hinting at it.

https://claude.ai/code/session_01BNG14mb8Bipkn8NqNdPHJ3