### PR TITLE
Fix AppShell overscroll bounce and iPad Aside breakpoint

### DIFF
--- a/src/components/AppShell/AppShell.module.css
+++ b/src/components/AppShell/AppShell.module.css
@@ -7,6 +7,8 @@
 
 .root {
   background-color: var(--mantine-navbar-background);
+  overflow: hidden;
+  overscroll-behavior: none;
 }
 
 .main {

--- a/src/components/AppShell/AppShell.tsx
+++ b/src/components/AppShell/AppShell.tsx
@@ -122,7 +122,7 @@ function AppShellComponent({
         }}
         aside={{
           width: ASIDE_DEFAULT_WIDTH,
-          breakpoint: "md",
+          breakpoint: "sm",
           collapsed: {
             mobile: true,
             desktop: !isChatPanelOpen,


### PR DESCRIPTION
The Main slot's `mr={-16}` (added with the chat panel) extends Main 16px
past the viewport on each side, making the document horizontally
scrollable. Combined with the body's default elastic overscroll, 2-finger
scrolling drags the entire container and reveals the page background.
Contain overflow on the AppShell root and disable overscroll there so
the box-cancelling negative margin no longer leaks scrollable area to
the document.

Separately, the Aside used `breakpoint: "md"` (62em / 992px) while the
Navbar uses `"sm"` (48em / 768px). On iPad portrait (~820–834px) we sit
above sm but below md, so the Navbar runs in desktop mode (toggle works)
while the Aside is forced into mobile mode where `collapsed.mobile: true`
pins it closed regardless of the toggle. Aligning the Aside breakpoint
with the Navbar lets the chat panel open on iPad the same way the navbar
does.

https://claude.ai/code/session_01GbSoWvQEynUsAxZF6qh4qv