### PR TITLE
Use BROWSER_FILEREADER protocol for efficient file registration

### DIFF
--- a/src/clients/DuckDbClient/DuckDbClient.ts
+++ b/src/clients/DuckDbClient/DuckDbClient.ts
@@ -536,13 +536,30 @@ class DuckDbClientImpl {
   }): Promise<void> {
     const { tableName, file, fileBytes } = options;
     const db = await this.#getDB();
+    // BROWSER_FILEREADER lets DuckDB do random-access reads against a Blob /
+    // File via `slice(...).arrayBuffer()`, avoiding a redundant full-buffer
+    // copy into DuckDB's WASM heap during ingest. XLSX still gets fully
+    // materialized below via `CREATE TABLE AS read_xlsx(...)`, but peak
+    // memory during the ingest step itself is meaningfully lower.
     if (file) {
-      const buffer = new Uint8Array(await file.arrayBuffer());
-      await db.registerFileBuffer(tableName, buffer);
+      await db.registerFileHandle(
+        tableName,
+        file,
+        duckdb.DuckDBDataProtocol.BROWSER_FILEREADER,
+        true,
+      );
       return;
     }
     if (fileBytes) {
-      await db.registerFileBuffer(tableName, fileBytes);
+      const blob = new Blob([fileBytes], {
+        type: MIMEType.APPLICATION_OPENXML_EXCEL,
+      });
+      await db.registerFileHandle(
+        tableName,
+        blob,
+        duckdb.DuckDBDataProtocol.BROWSER_FILEREADER,
+        true,
+      );
       return;
     }
     throw new Error("#registerXlsxFile: expected file or fileBytes");
@@ -564,9 +581,23 @@ class DuckDbClientImpl {
       throw new Error("Blob is not a parquet file");
     }
     const db = await this.#getDB();
-    const fileContents = await blob.arrayBuffer();
-    const parquetBuffer = new Uint8Array(fileContents);
-    await db.registerFileBuffer(tableName, parquetBuffer);
+    // Register the Blob directly as a file handle rather than copying its
+    // bytes into DuckDB's WASM heap. Combined with the `CREATE VIEW ... AS
+    // SELECT * FROM read_parquet(...)` in `loadParquet`, this lets DuckDB
+    // read only the column chunks and row groups it needs per query
+    // (projection + LIMIT pushdown) by slicing byte ranges out of the Blob.
+    // IDB- and fetch-backed Blobs in every modern browser are file-backed,
+    // so `blob.slice(...).arrayBuffer()` reads from disk on demand and
+    // does not materialize the whole parquet in JS memory. directIO is
+    // false so DuckDB caches hot pages in its buffer pool (important for
+    // repeated queries against the same dataset, e.g. column-by-column
+    // summary generation).
+    await db.registerFileHandle(
+      tableName,
+      blob,
+      duckdb.DuckDBDataProtocol.BROWSER_FILEREADER,
+      false,
+    );
   }
 
   /**

--- a/src/clients/DuckDbClient/DuckDbClient.ts
+++ b/src/clients/DuckDbClient/DuckDbClient.ts
@@ -117,7 +117,7 @@ type BaseDuckDbLoadXlsxOptions = {
  */
 export type DuckDbLoadXlsxOptions =
   | (BaseDuckDbLoadXlsxOptions & { file: File })
-  | (BaseDuckDbLoadXlsxOptions & { fileBytes: Uint8Array });
+  | (BaseDuckDbLoadXlsxOptions & { fileBytes: Uint8Array<ArrayBuffer> });
 
 /**
  * An object representing a row with unknown column types.
@@ -532,7 +532,7 @@ class DuckDbClientImpl {
   async #registerXlsxFile(options: {
     tableName: string;
     file?: File;
-    fileBytes?: Uint8Array;
+    fileBytes?: Uint8Array<ArrayBuffer>;
   }): Promise<void> {
     const { tableName, file, fileBytes } = options;
     const db = await this.#getDB();


### PR DESCRIPTION
## Summary
Refactored file registration in DuckDB client to use the `BROWSER_FILEREADER` protocol instead of materializing entire files into WASM heap memory. This enables lazy, on-demand reading of file contents via `Blob.slice()` operations.

## Key Changes
- **XLSX file registration**: Changed from `registerFileBuffer()` with full buffer copy to `registerFileHandle()` with `BROWSER_FILEREADER` protocol for the original `File` object
- **XLSX bytes registration**: Wrapped `fileBytes` in a `Blob` and registered via `registerFileHandle()` instead of direct buffer registration
- **Parquet file registration**: Replaced buffer materialization with `registerFileHandle()` using `BROWSER_FILEREADER` protocol, enabling DuckDB to read only necessary byte ranges via projection and LIMIT pushdown

## Implementation Details
- For XLSX files, the `BROWSER_FILEREADER` protocol allows DuckDB to perform random-access reads against `File`/`Blob` objects via `slice(...).arrayBuffer()`, reducing peak memory during ingest
- For Parquet files, lazy reading is particularly beneficial since DuckDB can read only required column chunks and row groups per query, with the `directIO=false` parameter enabling DuckDB's buffer pool caching for repeated queries
- Modern browsers back `Blob` objects with file-backed storage (IDB or fetch), so `slice()` operations read from disk on demand rather than materializing entire files in JavaScript memory

https://claude.ai/code/session_01VAN6ciAf5tx68QkFvC5MGu