### PR TITLE
chore(schema): sync datasets__virtual plan_steps comment to develop

### DIFF
--- a/supabase/schemas/20.datasets__virtual.sql
+++ b/supabase/schemas/20.datasets__virtual.sql
@@ -20,10 +20,9 @@ create table public.datasets__virtual (
   raw_sql text not null,
   -- When the dataset was produced by a multi-step LLM-proposed analytic
   -- plan, we save the plan as JSON ({ steps, rootMessage }) matching the
-  -- ChatPlan shape from `shared/types/chat.types.ts`.
-  -- This is NULL for virtual datasets created by one-shot SQL.
-  -- `plan_steps` is used to reopen the full step-by-step analysis
-  -- when the dataset is opened again.
+  -- ChatPlan shape from `shared/types/chat.types.ts`. This is NULL for
+  -- virtual datasets created by one-shot SQL. `plan_steps` is used to
+  -- reopen the full step-by-step analysis when the dataset is opened.
   plan_steps jsonb
 );
 


### PR DESCRIPTION
## Summary
- 3-line comment reflow on `supabase/schemas/20.datasets__virtual.sql` to match `feat/ict4d-demo`'s wording.
- No schema change, no behavioral impact.
- Closes the last remaining diff under `supabase/schemas/` between `develop` and `feat/ict4d-demo` so the deslop Phase 1 status can flip from `complete (pending trivial comment sync)` to flat `complete`.

## Test plan
- [x] `git diff origin/develop..origin/chore/sync-datasets-virtual-comment` shows only the 3-line comment reflow.
- [ ] CI lint/typecheck pass (no code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)