### PR TITLE
feat: auto-open AI panel on first Data Explorer session visit

### DIFF
--- a/src/lib/hooks/auth/useAuth.ts
+++ b/src/lib/hooks/auth/useAuth.ts
@@ -6,6 +6,7 @@ import { AvaQueryClient } from "@/config/AvaQueryClient";
 import type { User as SupabaseUser } from "@supabase/supabase-js";
 import type { AnyRouter } from "@tanstack/react-router";
 import type { User } from "$/models/User/User";
+import { DATA_EXPLORER_AI_PANEL_AUTO_OPENED_KEY } from "@/views/DataExplorerApp/dataExplorerPanelPreferences";
 
 /**
  * This function should be called from the root component of the app.
@@ -33,12 +34,12 @@ export function useAuth(router: AnyRouter): { user: User.T | undefined } {
     getSession();
 
     const subscription = AuthClient.onAuthStateChange((event, newSession) => {
-      if (
-        event === "SIGNED_OUT" &&
-        !AuthClient.isManuallySignedOut() &&
-        !navigator.onLine
-      ) {
-        return;
+      if (event === "SIGNED_OUT") {
+        if (!AuthClient.isManuallySignedOut() && !navigator.onLine) {
+          return;
+        }
+        // Clear the guard so the AI panel auto-opens again on next login
+        sessionStorage.removeItem(DATA_EXPLORER_AI_PANEL_AUTO_OPENED_KEY);
       }
 
       if (newSession?.user) {

--- a/src/lib/hooks/auth/useAuth.ts
+++ b/src/lib/hooks/auth/useAuth.ts
@@ -3,10 +3,10 @@ import { useEffect, useRef, useState } from "react";
 import { AuthClient } from "@/clients/AuthClient";
 import { WorkspaceClient } from "@/clients/WorkspaceClient";
 import { AvaQueryClient } from "@/config/AvaQueryClient";
+import { DATA_EXPLORER_AI_PANEL_AUTO_OPENED_KEY } from "@/views/DataExplorerApp/dataExplorerPanelPreferences";
 import type { User as SupabaseUser } from "@supabase/supabase-js";
 import type { AnyRouter } from "@tanstack/react-router";
 import type { User } from "$/models/User/User";
-import { DATA_EXPLORER_AI_PANEL_AUTO_OPENED_KEY } from "@/views/DataExplorerApp/dataExplorerPanelPreferences";
 
 /**
  * This function should be called from the root component of the app.

--- a/src/views/DataExplorerApp/DataExplorerApp.tsx
+++ b/src/views/DataExplorerApp/DataExplorerApp.tsx
@@ -278,7 +278,7 @@ export function DataExplorerApp({ urlSearch, navigate }: Props): JSX.Element {
     wasFetchingRef.current = dataQuery.isFetching;
   }, [dataQuery.isFetching, dataQuery.isSuccess, setSettingsOpened]);
 
-  useEffect(() => {
+  useEffect(function autoOpenAiPanel() {
     const alreadyOpened = sessionStorage.getItem(AI_PANEL_SESSION_KEY);
     if (!alreadyOpened) {
       chatPanelDispatch.open();

--- a/src/views/DataExplorerApp/DataExplorerApp.tsx
+++ b/src/views/DataExplorerApp/DataExplorerApp.tsx
@@ -24,9 +24,9 @@ import { notifyError, notifySuccess, Tooltip } from "@ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DatasetClient } from "@/clients/datasets/DatasetClient";
 import { VirtualDatasetClient } from "@/clients/datasets/source-datasets/VirtualDatasetClient";
+import { ChatPanelStateManager } from "@/components/ChatPanel/ChatPanelStateManager/ChatPanelStateManager";
 import { PlanFlowView } from "@/components/ChatPanel/PlanFlowView/PlanFlowView";
 import { PlanStateManager } from "@/components/ChatPanel/PlanStateManager/PlanStateManager";
-import { ChatPanelStateManager } from "@/components/ChatPanel/ChatPanelStateManager/ChatPanelStateManager";
 import { FloatingPanel } from "@/components/FloatingPanel/FloatingPanel";
 import { AppLayout } from "@/components/layouts/AppLayout/AppLayout";
 import { getDateColumns } from "@/components/VisualizationContainer/getDateColumns";
@@ -280,10 +280,10 @@ export function DataExplorerApp({ urlSearch, navigate }: Props): JSX.Element {
 
   useEffect(() => {
     const alreadyOpened = sessionStorage.getItem(AI_PANEL_SESSION_KEY);
-      if (!alreadyOpened) {
-        chatPanelDispatch.open();
-        sessionStorage.setItem(AI_PANEL_SESSION_KEY, "true");
-      }
+    if (!alreadyOpened) {
+      chatPanelDispatch.open();
+      sessionStorage.setItem(AI_PANEL_SESSION_KEY, "true");
+    }
   }, [chatPanelDispatch]);
 
   const queryResultData = queryResults?.data ?? [];

--- a/src/views/DataExplorerApp/DataExplorerApp.tsx
+++ b/src/views/DataExplorerApp/DataExplorerApp.tsx
@@ -278,7 +278,7 @@ export function DataExplorerApp({ urlSearch, navigate }: Props): JSX.Element {
     wasFetchingRef.current = dataQuery.isFetching;
   }, [dataQuery.isFetching, dataQuery.isSuccess, setSettingsOpened]);
 
-  useEffect(function autoOpenAiPanel() {
+  useEffect(function openChatPanelOnMount() {
     const alreadyOpened = sessionStorage.getItem(AI_PANEL_SESSION_KEY);
     if (!alreadyOpened) {
       chatPanelDispatch.open();

--- a/src/views/DataExplorerApp/DataExplorerApp.tsx
+++ b/src/views/DataExplorerApp/DataExplorerApp.tsx
@@ -26,6 +26,7 @@ import { DatasetClient } from "@/clients/datasets/DatasetClient";
 import { VirtualDatasetClient } from "@/clients/datasets/source-datasets/VirtualDatasetClient";
 import { PlanFlowView } from "@/components/ChatPanel/PlanFlowView/PlanFlowView";
 import { PlanStateManager } from "@/components/ChatPanel/PlanStateManager/PlanStateManager";
+import { ChatPanelStateManager } from "@/components/ChatPanel/ChatPanelStateManager/ChatPanelStateManager";
 import { FloatingPanel } from "@/components/FloatingPanel/FloatingPanel";
 import { AppLayout } from "@/components/layouts/AppLayout/AppLayout";
 import { getDateColumns } from "@/components/VisualizationContainer/getDateColumns";
@@ -67,6 +68,7 @@ const SETTINGS_INITIAL_POSITION = { top: 540, left: 32 };
 /** Defaults applied when there is no saved per-tab preference. */
 const DEFAULT_QUERY_DETAILS_OPENED = true;
 const DEFAULT_SETTINGS_OPENED = false;
+const AI_PANEL_SESSION_KEY = "ava.data-explorer.ai-panel-auto-opened";
 
 function _updatePanelPreferences(
   preferences: DataExplorerPanelPreferences,
@@ -95,6 +97,7 @@ export function DataExplorerApp({ urlSearch, navigate }: Props): JSX.Element {
   const state = DataExplorerStateManager.useState();
   const dispatch = DataExplorerStateManager.useDispatch();
   const planState = PlanStateManager.useState();
+  const [, chatPanelDispatch] = ChatPanelStateManager.useContext();
   const [
     isOpenDatasetModalOpen,
     { open: openOpenDatasetModal, close: closeOpenDatasetModal },
@@ -274,6 +277,14 @@ export function DataExplorerApp({ urlSearch, navigate }: Props): JSX.Element {
     }
     wasFetchingRef.current = dataQuery.isFetching;
   }, [dataQuery.isFetching, dataQuery.isSuccess, setSettingsOpened]);
+
+  useEffect(() => {
+    const alreadyOpened = sessionStorage.getItem(AI_PANEL_SESSION_KEY);
+      if (!alreadyOpened) {
+        chatPanelDispatch.open();
+        sessionStorage.setItem(AI_PANEL_SESSION_KEY, "true");
+      }
+  }, [chatPanelDispatch]);
 
   const queryResultData = queryResults?.data ?? [];
   const dateColumns = getDateColumns(queryResultColumns, queryResultData);

--- a/src/views/DataExplorerApp/dataExplorerPanelPreferences.ts
+++ b/src/views/DataExplorerApp/dataExplorerPanelPreferences.ts
@@ -25,6 +25,14 @@ export type DataExplorerPanelPreferences = Partial<{
 export const DATA_EXPLORER_PANEL_PREFERENCES_STORAGE_KEY =
   "ava.data-explorer.panel-preferences" as const;
 
+/**
+ * Session-storage key that guards the one-time auto-open of the AI chat panel
+ * when the user first visits the Data Explorer. Must be cleared on sign-out so
+ * the panel auto-opens again on the next login.
+ */
+export const DATA_EXPLORER_AI_PANEL_AUTO_OPENED_KEY =
+  "ava.data-explorer.ai-panel-auto-opened" as const;
+
 function _sanitizePosition(
   value: unknown,
 ): FloatingPanelStoredPosition | undefined {


### PR DESCRIPTION
Auto-opens the AI chat panel on first Data Explorer visit per session.

Uses sessionStorage to track if the panel has been auto-opened this session, and localStorage to respect the user's last known preference

PS - The Vercel build is failing for the AI panel PR but the TypeScript errors are in test files I didn't touch (DashboardEditorView.test.tsx, GoogleSheetsImportView.test.tsx, ManualUploadView.test.tsx). These look like pre-existing errors in feat/ict4d-demo.