### PR TITLE
fix: render SegmentedControl correctly on Invite Member modal open

### DIFF
--- a/src/views/WorkspaceSettingsPage/WorkspaceUsersForm/WorkspaceInviteModalFields.tsx
+++ b/src/views/WorkspaceSettingsPage/WorkspaceUsersForm/WorkspaceInviteModalFields.tsx
@@ -25,6 +25,7 @@ export type WorkspaceInviteModalFieldsRef = {
     tagIds: string[];
   };
   validate: () => boolean;
+  notifyModalOpened: () => void;
 };
 
 type Props = {
@@ -52,6 +53,7 @@ export const WorkspaceInviteModalFields = forwardRef<
   const [builtinPresetType, setBuiltinPresetType] =
     useState<BuiltinPresetType>("global_viewer");
   const [tagIds, setTagIds] = useState<string[]>([]);
+  const [segmentedControlKey, setSegmentedControlKey] = useState(0);
 
   useImperativeHandle(ref, (): WorkspaceInviteModalFieldsRef => {
     return {
@@ -64,6 +66,11 @@ export const WorkspaceInviteModalFields = forwardRef<
           return false;
         }
         return !innerFormRef.current.getForm().validate().hasErrors;
+      },
+      notifyModalOpened: () => {
+        setSegmentedControlKey((k) => {
+          return k + 1;
+        });
       },
     };
   });
@@ -100,6 +107,7 @@ export const WorkspaceInviteModalFields = forwardRef<
         ])}
       />
       <WorkspaceAppRoleMatrixForm
+        key={segmentedControlKey}
         rolesMatrix={rolesMatrix}
         onRolesMatrixChange={(next) => {
           setROlesMatrix(next);

--- a/src/views/WorkspaceSettingsPage/WorkspaceUsersForm/useWorkspaceInviteModal.tsx
+++ b/src/views/WorkspaceSettingsPage/WorkspaceUsersForm/useWorkspaceInviteModal.tsx
@@ -106,6 +106,11 @@ export function useWorkspaceInviteModal({
 
     modalId = modals.openConfirmModal({
       title: t`Invite a member`,
+      transitionProps: {
+        onEntered: () => {
+          fieldsRef.current?.notifyModalOpened(); 
+        },
+      },
       labels: {
         confirm: t`Send invite`,
         cancel: t`Cancel`,

--- a/src/views/WorkspaceSettingsPage/WorkspaceUsersForm/useWorkspaceInviteModal.tsx
+++ b/src/views/WorkspaceSettingsPage/WorkspaceUsersForm/useWorkspaceInviteModal.tsx
@@ -108,7 +108,7 @@ export function useWorkspaceInviteModal({
       title: t`Invite a member`,
       transitionProps: {
         onEntered: () => {
-          fieldsRef.current?.notifyModalOpened(); 
+          fieldsRef.current?.notifyModalOpened();
         },
       },
       labels: {


### PR DESCRIPTION
The role selector tabs weren't rendering the active indicator correctly until the user clicked. Fixed by remounting the SegmentedControl after the modal animation completes using transitionProps.onEntered and useImperativeHandle.