### PR TITLE
fix: use Model.make to construct ChatClientMessage (fixes broken Ask Avandar chatbot)

### DIFF
--- a/src/components/ChatPanel/useAvandarChatRuntime.ts
+++ b/src/components/ChatPanel/useAvandarChatRuntime.ts
@@ -174,10 +174,19 @@ export function useAvandarChatRuntime(): ReturnType<typeof useLocalRuntime> {
               return null;
             }
             return matchLiteral(chatMsg.role, {
-              system: { role: "system", content },
-              assistant: { role: "assistant", content },
-              user: { role: "user", content },
-            } as const);
+              system: Model.make("ChatClientMessage", {
+                role: "system" as const,
+                content,
+              }),
+              assistant: Model.make("ChatClientMessage", {
+                role: "assistant" as const,
+                content,
+              }),
+              user: Model.make("ChatClientMessage", {
+                role: "user" as const,
+                content,
+              }),
+            });
           })
           .filter((message): message is ChatClientMessage.T => {
             return isNotNull(message);


### PR DESCRIPTION
**Critical fix:** chatbot is currently broken in production

**Bug:** The frontend constructs chat message objects as bare object literals and uses `.filter` to type-assert them as `ChatClientMessage.T`, but this doesn't actually add the required `__type: "ChatClientMessage"` field. The server's Zod schema rejects these messages with:

```
Error: Error parsing body params. ✖ Invalid input: expected "ChatClientMessage"
  → at messages[0].__type
```

Fix: Use `Model.make("ChatClientMessage", {...})` to properly construct message objects with the required `__type` field.

Testing: Reproduced the error on latest `feat/ict4d-demo` (same as prod), confirmed fix resolves it locally.