### PR TITLE
fix: stabilize render function references in pfield hooks to prevent input focus loss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ tests/data/large/
 # These patterns are tripwires in case a tool drops a worktree directory here by mistake.
 worktrees/
 .worktrees/
+supabase/snippets/

--- a/src/views/DashboardApp/AvaPage/pblocks/DataVizPBlock/buildDataVizPBlockConfig.tsx
+++ b/src/views/DashboardApp/AvaPage/pblocks/DataVizPBlock/buildDataVizPBlockConfig.tsx
@@ -1,5 +1,6 @@
 import { useLingui } from "@lingui/react/macro";
 import { ComponentConfig } from "@puckeditor/core";
+import { useMemo } from "react";
 import { DashboardId } from "$/models/Dashboard/Dashboard.types";
 import { VizConfigs, VizTypes } from "$/models/vizs/VizConfig/VizConfigs";
 import { DEFAULT_GLOBAL_FILTER_SUBSCRIPTION } from "@/views/DashboardApp/AvaPage/pblocks/DataVizPBlock/DataVizPBlock/dataVizFilters";
@@ -57,34 +58,43 @@ export function useDataVizPBlockConfig(options: {
     useGlobalFilterSubscriptionPFieldConfig();
   const localFiltersFieldConfig = useLocalFiltersPFieldConfig();
 
-  const vizTypeOptions = VizTypes.map((vizType) => {
-    return {
-      label: VizConfigs.getDisplayName(vizType),
-      value: vizType,
-    };
-  });
-
-  return {
-    label: puckDrawerLabel("Data Visualization"),
-    fields: {
-      nlQuery: nlQueryFieldConfig,
-      vizType: {
-        label: t`Visualization Type`,
-        type: "select",
-        options: vizTypeOptions,
-      },
-      vizConfig: vizConfigFieldConfig,
-      globalFilterSubscription: globalFilterSubscriptionFieldConfig,
-      localFilters: localFiltersFieldConfig,
+  return useMemo(
+    () => {
+      return {
+        label: puckDrawerLabel("Data Visualization"),
+        fields: {
+          nlQuery: nlQueryFieldConfig,
+          vizType: {
+            label: t`Visualization Type`,
+            type: "select",
+            options: VizTypes.map((vizType) => {
+              return {
+                label: VizConfigs.getDisplayName(vizType),
+                value: vizType,
+              };
+            }),
+          },
+          vizConfig: vizConfigFieldConfig,
+          globalFilterSubscription: globalFilterSubscriptionFieldConfig,
+          localFilters: localFiltersFieldConfig,
+        },
+        defaultProps,
+        resolveData: (data, { changed }) => {
+          const nextProps = resolveDataVizPBlockProps({
+            props: data.props,
+            changed,
+          });
+          return { props: nextProps };
+        },
+        render: DataVizPBlock,
+      };
     },
-    defaultProps,
-    resolveData: (data, { changed }) => {
-      const nextProps = resolveDataVizPBlockProps({
-        props: data.props,
-        changed,
-      });
-      return { props: nextProps };
-    },
-    render: DataVizPBlock,
-  };
+    [
+      t,
+      nlQueryFieldConfig,
+      vizConfigFieldConfig,
+      globalFilterSubscriptionFieldConfig,
+      localFiltersFieldConfig,
+    ],
+  );
 }

--- a/src/views/DashboardApp/AvaPage/pblocks/DataVizPBlock/buildDataVizPBlockConfig.tsx
+++ b/src/views/DashboardApp/AvaPage/pblocks/DataVizPBlock/buildDataVizPBlockConfig.tsx
@@ -1,8 +1,8 @@
 import { useLingui } from "@lingui/react/macro";
 import { ComponentConfig } from "@puckeditor/core";
-import { useMemo } from "react";
 import { DashboardId } from "$/models/Dashboard/Dashboard.types";
 import { VizConfigs, VizTypes } from "$/models/vizs/VizConfig/VizConfigs";
+import { useMemo } from "react";
 import { DEFAULT_GLOBAL_FILTER_SUBSCRIPTION } from "@/views/DashboardApp/AvaPage/pblocks/DataVizPBlock/DataVizPBlock/dataVizFilters";
 import { DataVizPBlock } from "@/views/DashboardApp/AvaPage/pblocks/DataVizPBlock/DataVizPBlock/DataVizPBlock";
 import { resolveDataVizPBlockProps } from "@/views/DashboardApp/AvaPage/pblocks/DataVizPBlock/resolveDataVizPBlockProps";
@@ -58,43 +58,40 @@ export function useDataVizPBlockConfig(options: {
     useGlobalFilterSubscriptionPFieldConfig();
   const localFiltersFieldConfig = useLocalFiltersPFieldConfig();
 
-  return useMemo(
-    () => {
-      return {
-        label: puckDrawerLabel("Data Visualization"),
-        fields: {
-          nlQuery: nlQueryFieldConfig,
-          vizType: {
-            label: t`Visualization Type`,
-            type: "select",
-            options: VizTypes.map((vizType) => {
-              return {
-                label: VizConfigs.getDisplayName(vizType),
-                value: vizType,
-              };
-            }),
-          },
-          vizConfig: vizConfigFieldConfig,
-          globalFilterSubscription: globalFilterSubscriptionFieldConfig,
-          localFilters: localFiltersFieldConfig,
+  return useMemo(() => {
+    return {
+      label: puckDrawerLabel("Data Visualization"),
+      fields: {
+        nlQuery: nlQueryFieldConfig,
+        vizType: {
+          label: t`Visualization Type`,
+          type: "select",
+          options: VizTypes.map((vizType) => {
+            return {
+              label: VizConfigs.getDisplayName(vizType),
+              value: vizType,
+            };
+          }),
         },
-        defaultProps,
-        resolveData: (data, { changed }) => {
-          const nextProps = resolveDataVizPBlockProps({
-            props: data.props,
-            changed,
-          });
-          return { props: nextProps };
-        },
-        render: DataVizPBlock,
-      };
-    },
-    [
-      t,
-      nlQueryFieldConfig,
-      vizConfigFieldConfig,
-      globalFilterSubscriptionFieldConfig,
-      localFiltersFieldConfig,
-    ],
-  );
+        vizConfig: vizConfigFieldConfig,
+        globalFilterSubscription: globalFilterSubscriptionFieldConfig,
+        localFilters: localFiltersFieldConfig,
+      },
+      defaultProps,
+      resolveData: (data, { changed }) => {
+        const nextProps = resolveDataVizPBlockProps({
+          props: data.props,
+          changed,
+        });
+        return { props: nextProps };
+      },
+      render: DataVizPBlock,
+    };
+  }, [
+    t,
+    nlQueryFieldConfig,
+    vizConfigFieldConfig,
+    globalFilterSubscriptionFieldConfig,
+    localFiltersFieldConfig,
+  ]);
 }

--- a/src/views/DashboardApp/AvaPage/pfields/ContainerMaxWidthPField/buildContainerMaxWidthPFieldConfig.tsx
+++ b/src/views/DashboardApp/AvaPage/pfields/ContainerMaxWidthPField/buildContainerMaxWidthPFieldConfig.tsx
@@ -25,14 +25,11 @@ export function useContainerMaxWidthPFieldConfig(): CustomField<ContainerMaxWidt
     [],
   );
 
-  return useMemo(
-    () => {
-      return {
-        label: t`Container max width`,
-        type: "custom",
-        render,
-      };
-    },
-    [t, render],
-  );
+  return useMemo(() => {
+    return {
+      label: t`Container max width`,
+      type: "custom",
+      render,
+    };
+  }, [t, render]);
 }

--- a/src/views/DashboardApp/AvaPage/pfields/ContainerMaxWidthPField/buildContainerMaxWidthPFieldConfig.tsx
+++ b/src/views/DashboardApp/AvaPage/pfields/ContainerMaxWidthPField/buildContainerMaxWidthPFieldConfig.tsx
@@ -1,5 +1,6 @@
 import { useLingui } from "@lingui/react/macro";
 import { CustomField } from "@puckeditor/core";
+import { useCallback, useMemo } from "react";
 import { AvaPageFieldProps } from "@/views/DashboardApp/AvaPage/AvaPage.types";
 import {
   ContainerMaxWidthPField,
@@ -16,11 +17,22 @@ import {
 // eslint-disable-next-line max-len
 export function useContainerMaxWidthPFieldConfig(): CustomField<ContainerMaxWidthValue> {
   const { t } = useLingui();
-  return {
-    label: t`Container max width`,
-    type: "custom",
-    render: (props: AvaPageFieldProps<ContainerMaxWidthValue>) => {
+
+  const render = useCallback(
+    (props: AvaPageFieldProps<ContainerMaxWidthValue>) => {
       return <ContainerMaxWidthPField {...props} />;
     },
-  };
+    [],
+  );
+
+  return useMemo(
+    () => {
+      return {
+        label: t`Container max width`,
+        type: "custom",
+        render,
+      };
+    },
+    [t, render],
+  );
 }

--- a/src/views/DashboardApp/AvaPage/pfields/GlobalFilterSubscriptionPField/buildGlobalFilterSubscriptionPFieldConfig.tsx
+++ b/src/views/DashboardApp/AvaPage/pfields/GlobalFilterSubscriptionPField/buildGlobalFilterSubscriptionPFieldConfig.tsx
@@ -1,5 +1,6 @@
 import { useLingui } from "@lingui/react/macro";
 import { CustomField } from "@puckeditor/core";
+import { useMemo } from "react";
 import { GlobalFilterSubscriptionPField } from "@/views/DashboardApp/AvaPage/pfields/GlobalFilterSubscriptionPField/GlobalFilterSubscriptionPField";
 import type { GlobalFilterSubscription } from "@/views/DashboardApp/AvaPage/pblocks/DataVizPBlock/DataVizPBlock/dataVizFilters";
 
@@ -11,9 +12,14 @@ import type { GlobalFilterSubscription } from "@/views/DashboardApp/AvaPage/pblo
 // eslint-disable-next-line max-len
 export function useGlobalFilterSubscriptionPFieldConfig(): CustomField<GlobalFilterSubscription> {
   const { t } = useLingui();
-  return {
-    label: t`Global filters`,
-    type: "custom",
-    render: GlobalFilterSubscriptionPField,
-  };
+  return useMemo(
+    () => {
+      return {
+        label: t`Global filters`,
+        type: "custom",
+        render: GlobalFilterSubscriptionPField,
+      };
+    },
+    [t],
+  );
 }

--- a/src/views/DashboardApp/AvaPage/pfields/GlobalFilterSubscriptionPField/buildGlobalFilterSubscriptionPFieldConfig.tsx
+++ b/src/views/DashboardApp/AvaPage/pfields/GlobalFilterSubscriptionPField/buildGlobalFilterSubscriptionPFieldConfig.tsx
@@ -12,14 +12,11 @@ import type { GlobalFilterSubscription } from "@/views/DashboardApp/AvaPage/pblo
 // eslint-disable-next-line max-len
 export function useGlobalFilterSubscriptionPFieldConfig(): CustomField<GlobalFilterSubscription> {
   const { t } = useLingui();
-  return useMemo(
-    () => {
-      return {
-        label: t`Global filters`,
-        type: "custom",
-        render: GlobalFilterSubscriptionPField,
-      };
-    },
-    [t],
-  );
+  return useMemo(() => {
+    return {
+      label: t`Global filters`,
+      type: "custom",
+      render: GlobalFilterSubscriptionPField,
+    };
+  }, [t]);
 }

--- a/src/views/DashboardApp/AvaPage/pfields/LocalFiltersPField/buildLocalFiltersPFieldConfig.tsx
+++ b/src/views/DashboardApp/AvaPage/pfields/LocalFiltersPField/buildLocalFiltersPFieldConfig.tsx
@@ -13,14 +13,11 @@ export function useLocalFiltersPFieldConfig(): CustomField<
   readonly LocalFilter[]
 > {
   const { t } = useLingui();
-  return useMemo(
-    () => {
-      return {
-        label: t`Local filters (viewer-editable, this chart only)`,
-        type: "custom",
-        render: LocalFiltersPField,
-      };
-    },
-    [t],
-  );
+  return useMemo(() => {
+    return {
+      label: t`Local filters (viewer-editable, this chart only)`,
+      type: "custom",
+      render: LocalFiltersPField,
+    };
+  }, [t]);
 }

--- a/src/views/DashboardApp/AvaPage/pfields/LocalFiltersPField/buildLocalFiltersPFieldConfig.tsx
+++ b/src/views/DashboardApp/AvaPage/pfields/LocalFiltersPField/buildLocalFiltersPFieldConfig.tsx
@@ -1,5 +1,6 @@
 import { useLingui } from "@lingui/react/macro";
 import { CustomField } from "@puckeditor/core";
+import { useMemo } from "react";
 import { LocalFiltersPField } from "@/views/DashboardApp/AvaPage/pfields/LocalFiltersPField/LocalFiltersPField";
 import type { LocalFilter } from "@/views/DashboardApp/AvaPage/pblocks/DataVizPBlock/DataVizPBlock/dataVizFilters";
 
@@ -12,9 +13,14 @@ export function useLocalFiltersPFieldConfig(): CustomField<
   readonly LocalFilter[]
 > {
   const { t } = useLingui();
-  return {
-    label: t`Local filters (viewer-editable, this chart only)`,
-    type: "custom",
-    render: LocalFiltersPField,
-  };
+  return useMemo(
+    () => {
+      return {
+        label: t`Local filters (viewer-editable, this chart only)`,
+        type: "custom",
+        render: LocalFiltersPField,
+      };
+    },
+    [t],
+  );
 }

--- a/src/views/DashboardApp/AvaPage/pfields/NLQueryPField/buildNLQueryFieldConfig.tsx
+++ b/src/views/DashboardApp/AvaPage/pfields/NLQueryPField/buildNLQueryFieldConfig.tsx
@@ -1,5 +1,6 @@
 import { useLingui } from "@lingui/react/macro";
 import { CustomField } from "@puckeditor/core";
+import { useMemo } from "react";
 import {
   NLQuery,
   NLQueryPField,
@@ -13,9 +14,14 @@ import {
  */
 export function useNLQueryPFieldConfig(): CustomField<NLQuery> {
   const { t } = useLingui();
-  return {
-    label: t`Prompt`,
-    type: "custom",
-    render: NLQueryPField,
-  };
+  return useMemo(
+    () => {
+      return {
+        label: t`Prompt`,
+        type: "custom",
+        render: NLQueryPField,
+      };
+    },
+    [t],
+  );
 }

--- a/src/views/DashboardApp/AvaPage/pfields/NLQueryPField/buildNLQueryFieldConfig.tsx
+++ b/src/views/DashboardApp/AvaPage/pfields/NLQueryPField/buildNLQueryFieldConfig.tsx
@@ -14,14 +14,11 @@ import {
  */
 export function useNLQueryPFieldConfig(): CustomField<NLQuery> {
   const { t } = useLingui();
-  return useMemo(
-    () => {
-      return {
-        label: t`Prompt`,
-        type: "custom",
-        render: NLQueryPField,
-      };
-    },
-    [t],
-  );
+  return useMemo(() => {
+    return {
+      label: t`Prompt`,
+      type: "custom",
+      render: NLQueryPField,
+    };
+  }, [t]);
 }

--- a/src/views/DashboardApp/AvaPage/pfields/VizConfigPField/buildVizConfigPFieldConfig.tsx
+++ b/src/views/DashboardApp/AvaPage/pfields/VizConfigPField/buildVizConfigPFieldConfig.tsx
@@ -1,5 +1,6 @@
 import { useLingui } from "@lingui/react/macro";
 import { CustomField } from "@puckeditor/core";
+import { useCallback, useMemo } from "react";
 import { DashboardId } from "$/models/Dashboard/Dashboard.types";
 import { Workspace } from "$/models/Workspace/Workspace";
 import { VizConfigPField } from "@/views/DashboardApp/AvaPage/pfields/VizConfigPField/VizConfigPField";
@@ -18,18 +19,36 @@ export function useVizConfigPFieldConfig(options: {
   dashboardId: DashboardId;
 }): CustomField<VizConfig> {
   const { t } = useLingui();
-  return {
-    label: t`Visualization Settings`,
-    type: "custom",
-    render: ({ value, onChange }) => {
+  const { workspaceId, dashboardId } = options;
+
+  const render = useCallback(
+    ({
+      value,
+      onChange,
+    }: {
+      value: VizConfig;
+      onChange: (value: VizConfig) => void;
+    }) => {
       return (
         <VizConfigPField
           value={value}
           onChange={onChange}
-          workspaceId={options.workspaceId}
-          dashboardId={options.dashboardId}
+          workspaceId={workspaceId}
+          dashboardId={dashboardId}
         />
       );
     },
-  };
+    [workspaceId, dashboardId],
+  );
+
+  return useMemo(
+    () => {
+      return {
+        label: t`Visualization Settings`,
+        type: "custom",
+        render,
+      };
+    },
+    [t, render],
+  );
 }

--- a/src/views/DashboardApp/AvaPage/pfields/VizConfigPField/buildVizConfigPFieldConfig.tsx
+++ b/src/views/DashboardApp/AvaPage/pfields/VizConfigPField/buildVizConfigPFieldConfig.tsx
@@ -1,8 +1,8 @@
 import { useLingui } from "@lingui/react/macro";
 import { CustomField } from "@puckeditor/core";
-import { useCallback, useMemo } from "react";
 import { DashboardId } from "$/models/Dashboard/Dashboard.types";
 import { Workspace } from "$/models/Workspace/Workspace";
+import { useCallback, useMemo } from "react";
 import { VizConfigPField } from "@/views/DashboardApp/AvaPage/pfields/VizConfigPField/VizConfigPField";
 import type { VizConfig } from "$/models/vizs/VizConfig/VizConfig.types";
 
@@ -41,14 +41,11 @@ export function useVizConfigPFieldConfig(options: {
     [workspaceId, dashboardId],
   );
 
-  return useMemo(
-    () => {
-      return {
-        label: t`Visualization Settings`,
-        type: "custom",
-        render,
-      };
-    },
-    [t, render],
-  );
+  return useMemo(() => {
+    return {
+      label: t`Visualization Settings`,
+      type: "custom",
+      render,
+    };
+  }, [t, render]);
 }

--- a/supabase/snippets/Untitled query 741.sql
+++ b/supabase/snippets/Untitled query 741.sql
@@ -1,2 +1,0 @@
-DELETE FROM public.workspaces WHERE owner_id = '5b753cb6-3864-42e5-be42-3efb63653c0f';
-DELETE FROM auth.users WHERE email = 'anujsp2001@gmail.com';

--- a/supabase/snippets/Untitled query 741.sql
+++ b/supabase/snippets/Untitled query 741.sql
@@ -1,0 +1,2 @@
+DELETE FROM public.workspaces WHERE owner_id = '5b753cb6-3864-42e5-be42-3efb63653c0f';
+DELETE FROM auth.users WHERE email = 'anujsp2001@gmail.com';


### PR DESCRIPTION
**Bug**: In the dashboard editor, typing into any sidebar input field (series label, axis title, color picker, etc.) caused the field to lose focus after every keystroke. Users had to click back into the field for each letter.

**Root cause**: `useVizConfigPFieldConfig` and the other pfield hooks returned a new render function reference on every `render` (no `useCallback`/`useMemo`). Puck treats `field.render` as a React component type, when the reference changes, React unmounts and remounts the component, destroying the focused DOM node mid-keystroke.

**Fix**: Wrapped `render` functions with `useCallback` and configs with `useMemo` across all 6 pfield hooks so React sees stable references and doesn't remount the input components on re-renders.

**Testing**: Verified all sidebar inputs retain focus across keystrokes, switching between blocks works correctly, and filter block inputs are unaffected.