### PR TITLE
fix: wrap filter buttons to prevent overflow in narrow containers

### DIFF
--- a/src/views/DataExplorerApp/QueryForm/QueryFiltersField.module.css
+++ b/src/views/DataExplorerApp/QueryForm/QueryFiltersField.module.css
@@ -1,0 +1,7 @@
+/* Allow the header row (combinator + "+ Rule" / "+ Group" buttons) and each
+   rule row (field + operator + value + remove button) to wrap onto multiple
+   lines in narrow containers instead of overflowing. */
+.queryFiltersField :global(.ruleGroup-header),
+.queryFiltersField :global(.rule) {
+  flex-wrap: wrap;
+}

--- a/src/views/DataExplorerApp/QueryForm/QueryFiltersField.module.css
+++ b/src/views/DataExplorerApp/QueryForm/QueryFiltersField.module.css
@@ -1,7 +1,9 @@
 /* Allow the header row (combinator + "+ Rule" / "+ Group" buttons) and each
    rule row (field + operator + value + remove button) to wrap onto multiple
    lines in narrow containers instead of overflowing. */
+/* stylelint-disable selector-class-pattern -- third-party react-querybuilder class names */
 .queryFiltersField :global(.ruleGroup-header),
 .queryFiltersField :global(.rule) {
   flex-wrap: wrap;
 }
+/* stylelint-enable selector-class-pattern */

--- a/src/views/DataExplorerApp/QueryForm/QueryFiltersField.tsx
+++ b/src/views/DataExplorerApp/QueryForm/QueryFiltersField.tsx
@@ -234,7 +234,10 @@ export function QueryFiltersField({
   }
 
   return (
-    <Box data-testid="query-filters-field" className={classes.queryFiltersField}>
+    <Box
+      data-testid="query-filters-field"
+      className={classes.queryFiltersField}
+    >
       <QueryBuilderMantine>
         <QueryBuilder
           fields={fields}

--- a/src/views/DataExplorerApp/QueryForm/QueryFiltersField.tsx
+++ b/src/views/DataExplorerApp/QueryForm/QueryFiltersField.tsx
@@ -8,6 +8,7 @@ import {
 import { useMemo } from "react";
 import { QueryBuilder } from "react-querybuilder";
 import "react-querybuilder/dist/query-builder.css";
+import classes from "./QueryFiltersField.module.css";
 import type { QueryColumnRead } from "$/models/queries/QueryColumn/QueryColumn.types";
 import type {
   QueryFilterCombinator,
@@ -233,7 +234,7 @@ export function QueryFiltersField({
   }
 
   return (
-    <Box data-testid="query-filters-field">
+    <Box data-testid="query-filters-field" className={classes.queryFiltersField}>
       <QueryBuilderMantine>
         <QueryBuilder
           fields={fields}


### PR DESCRIPTION
**Bug**: In the Filters (Where) section of both the Query Details panel and the Dashboard sidebar, the `+ Rule`, `+ Group`, and remove buttons were being cut off or overflowing when the container was narrow. Users couldn't see or click the buttons properly.

**Root cause**: The `react-querybuilder` library's `.ruleGroup-header` flex row has no `flex-wrap`, so buttons overflow horizontally instead of wrapping when the container is too narrow.

**Fix**: Added `flex-wrap: wrap` override scoped to the `[data-testid="query-filters-field"]` wrapper via a CSS module, so buttons wrap to the next line instead of overflowing.

**Note**: At Puck's minimum dashboard sidebar width (192px, hardcoded in Puck's bundle), some content is still truncated. Increasing this minimum would require patching Puck's compiled bundle which is risky, leaving this as a known limitation for now.

**Testing**: Verified in both Query Details panel and Dashboard sidebar, buttons and filter fields are now visible and usable at normal widths.