### PR TITLE
fix: prevent dashboard crash when globalFilterSubscription is undefined

### DIFF
--- a/src/views/DashboardApp/AvaPage/pfields/GlobalFilterSubscriptionPField/GlobalFilterSubscriptionPField.tsx
+++ b/src/views/DashboardApp/AvaPage/pfields/GlobalFilterSubscriptionPField/GlobalFilterSubscriptionPField.tsx
@@ -10,9 +10,10 @@ import {
 import { IconInfoCircle } from "@tabler/icons-react";
 import { DashboardFilterStateManager } from "@/views/DashboardApp/DashboardFilterStateManager/DashboardFilterStateManager";
 import type { AvaPageFieldProps } from "@/views/DashboardApp/AvaPage/AvaPage.types";
-import type {
-  GlobalFilterSubscription,
-  GlobalFilterSubscriptionMode,
+import {
+  DEFAULT_GLOBAL_FILTER_SUBSCRIPTION,
+  type GlobalFilterSubscription,
+  type GlobalFilterSubscriptionMode,
 } from "@/views/DashboardApp/AvaPage/pblocks/DataVizPBlock/DataVizPBlock/dataVizFilters";
 
 type Props = AvaPageFieldProps<GlobalFilterSubscription>;
@@ -43,17 +44,25 @@ export function GlobalFilterSubscriptionPField({
   const { filtersById } = DashboardFilterStateManager.useState();
   const registeredFilters = Object.values(filtersById);
 
+  // Guard against Puck rendering the field before resolveData backfills the
+  // default - can happen when a block enters the store without this field
+  // (e.g. saved from the Data Explorer) and is then selected before the
+  // initial resolveData pass runs, or when undo restores that
+  // pre-resolve state.
+  const subscription = value ?? DEFAULT_GLOBAL_FILTER_SUBSCRIPTION;
+
   const _setMode = (mode: GlobalFilterSubscriptionMode): void => {
     onChange({
       mode,
       // Reset the explicit subscription list when leaving "selected" so
       // future toggles start clean.
-      subscribedFilterIds: mode === "selected" ? value.subscribedFilterIds : [],
+      subscribedFilterIds:
+        mode === "selected" ? subscription.subscribedFilterIds : [],
     });
   };
 
   const _toggleFilter = (filterId: string, checked: boolean): void => {
-    const next = new Set(value.subscribedFilterIds);
+    const next = new Set(subscription.subscribedFilterIds);
     if (checked) next.add(filterId);
     else next.delete(filterId);
     onChange({
@@ -66,7 +75,7 @@ export function GlobalFilterSubscriptionPField({
     <Stack gap={6}>
       <SegmentedControl
         size="xs"
-        value={value.mode}
+        value={subscription.mode}
         onChange={(m) => {
           _setMode(m as GlobalFilterSubscriptionMode);
         }}
@@ -78,10 +87,10 @@ export function GlobalFilterSubscriptionPField({
         fullWidth
       />
       <Text size="xs" c="dimmed">
-        {modeDescriptions[value.mode]}
+        {modeDescriptions[subscription.mode]}
       </Text>
 
-      {value.mode === "selected" ?
+      {subscription.mode === "selected" ?
         registeredFilters.length === 0 ?
           <Alert
             color="blue"
@@ -110,7 +119,9 @@ export function GlobalFilterSubscriptionPField({
                         </Text>
                       </Text>
                     }
-                    checked={value.subscribedFilterIds.includes(f.filterId)}
+                    checked={subscription.subscribedFilterIds.includes(
+                      f.filterId,
+                    )}
                     onChange={(e) => {
                       _toggleFilter(f.filterId, e.currentTarget.checked);
                     }}

--- a/src/views/DashboardApp/AvaPage/pfields/GlobalFilterSubscriptionPField/GlobalFilterSubscriptionPField.tsx
+++ b/src/views/DashboardApp/AvaPage/pfields/GlobalFilterSubscriptionPField/GlobalFilterSubscriptionPField.tsx
@@ -8,12 +8,12 @@ import {
   Text,
 } from "@mantine/core";
 import { IconInfoCircle } from "@tabler/icons-react";
+import { DEFAULT_GLOBAL_FILTER_SUBSCRIPTION } from "@/views/DashboardApp/AvaPage/pblocks/DataVizPBlock/DataVizPBlock/dataVizFilters";
 import { DashboardFilterStateManager } from "@/views/DashboardApp/DashboardFilterStateManager/DashboardFilterStateManager";
 import type { AvaPageFieldProps } from "@/views/DashboardApp/AvaPage/AvaPage.types";
-import {
-  DEFAULT_GLOBAL_FILTER_SUBSCRIPTION,
-  type GlobalFilterSubscription,
-  type GlobalFilterSubscriptionMode,
+import type {
+  GlobalFilterSubscription,
+  GlobalFilterSubscriptionMode,
 } from "@/views/DashboardApp/AvaPage/pblocks/DataVizPBlock/DataVizPBlock/dataVizFilters";
 
 type Props = AvaPageFieldProps<GlobalFilterSubscription>;

--- a/src/views/DataExplorerApp/SaveToDashboardModal/createDataVizBlock.ts
+++ b/src/views/DataExplorerApp/SaveToDashboardModal/createDataVizBlock.ts
@@ -1,4 +1,9 @@
 import { uuid } from "$/lib/uuid";
+import { DEFAULT_GLOBAL_FILTER_SUBSCRIPTION } from "@/views/DashboardApp/AvaPage/pblocks/DataVizPBlock/DataVizPBlock/dataVizFilters";
+import type {
+  GlobalFilterSubscription,
+  LocalFilter,
+} from "@/views/DashboardApp/AvaPage/pblocks/DataVizPBlock/DataVizPBlock/dataVizFilters";
 import type {
   VizConfig,
   VizType,
@@ -34,6 +39,8 @@ export type DataVizDashboardBlock = {
     };
     vizType: VizType;
     vizConfig: VizConfig;
+    globalFilterSubscription: GlobalFilterSubscription;
+    localFilters: readonly LocalFilter[];
   };
 };
 
@@ -71,6 +78,8 @@ export function createDataVizBlock(args: {
       },
       vizType: args.vizType,
       vizConfig: args.vizConfig,
+      globalFilterSubscription: DEFAULT_GLOBAL_FILTER_SUBSCRIPTION,
+      localFilters: [],
     },
   };
 }


### PR DESCRIPTION
Bug: Clicking on a DataViz block in the dashboard editor after undoing filter changes caused a crash: `TypeError: Cannot read properties of undefined (reading 'mode') in GlobalFilterSubscriptionPField.tsx`.

Root cause: `createDataVizBlock.ts` was creating blocks without `globalFilterSubscription` and `localFilters` fields added in the V4 schema migration. When a block is saved from Data Explorer to a dashboard, it enters Puck's undo history as Entry 0 without these fields. `resolveData` backfills them on mount (Entry 1), but undoing twice restores Entry 0, the invalid state, causing `GlobalFilterSubscriptionPField` to receive `value = undefined` and crash.

Fix:
1. Primary - Added `globalFilterSubscription: DEFAULT_GLOBAL_FILTER_SUBSCRIPTION` and `localFilters: []` to `createDataVizBlock.ts` so Entry 0 is always valid and the undo path can never reach an undefined state
2. Defensive - Added null guard `value ?? DEFAULT_GLOBAL_FILTER_SUBSCRIPTION` in `GlobalFilterSubscriptionPField.tsx` to protect against any other code paths that might produce undefined

Testing: Reproduced the crash locally (add DataViz from Data Explorer, undo filter changes multiple times, click block), crash no longer occurs after the fix.