### PR TITLE
fix: restore scroll on dashboard preview by replacing overflow hidden with overflow-x clip

### DIFF
--- a/src/components/AppShell/AppShell.module.css
+++ b/src/components/AppShell/AppShell.module.css
@@ -5,10 +5,17 @@
   overscroll-behavior: none;
 }
 
+/*
+ * overflow-x: clip clips the 32px horizontal bleed from Main's ml/mr={-16}
+ * without creating a scroll container. Unlike overflow: hidden, clip does not
+ * absorb wheel events, so window-level vertical scroll works on pages that
+ * have no inner overflow:auto container (e.g. dashboard preview). The
+ * overflow is excluded from the document's scroll area, preventing the
+ * horizontal elastic-overscroll bounce as well.
+ */
 .root {
   background-color: var(--mantine-navbar-background);
-  overflow: hidden;
-  overscroll-behavior: none;
+  overflow-x: clip;
 }
 
 /*


### PR DESCRIPTION
**Bug**: On the dashboard preview page, scrolling with mouse wheel or trackpad didn't work. The scrollbar was only accessible at the very far right edge of the page.

**Root cause**: A previous commit added `overflow: hidden` and `overscroll-behavior: none` to `.root` in `AppShell.module.css` to fix horizontal elastic overscroll on iPad. However, `overflow: hidden` creates a CSS scroll container, with `overscroll-behavior: none`, wheel events targeting content inside AppShell hit this "always-at-boundary" scroll container and get absorbed, never reaching the window. The editor wasn't affected because it has an explicit `overflow: auto` inner container, but the dashboard preview renders directly into `AppShell.Main` with no intermediate scroll container.

**Fix**: Changed `overflow: hidden` to `overflow-x: clip`. Unlike `hidden`, `clip` does not create a scroll container, so wheel events pass through freely to the window. It still clips the 32px horizontal bleed from `Main`'s negative margins, preventing the original elastic overscroll issue.

**Testing**: Verified scroll works correctly on dashboard preview with mouse wheel/trackpad. Editor and Data Explorer unaffected.