### PR TITLE
fix: resolve axis label visibility, color customization, and overlap issues in charts

### DIFF
--- a/src/lib/ui/viz/AreaChart.tsx
+++ b/src/lib/ui/viz/AreaChart.tsx
@@ -84,6 +84,11 @@ export function AreaChart({
     return applyChartStyle(chartStyle, baseXAxisProps);
   }, [chartStyle, baseXAxisProps]);
 
+  const xLabelText = chartStyle?.xAxis?.label;
+  const yLabelText = chartStyle?.yAxis?.label;
+  const hasXLabel = xLabelText !== undefined && xLabelText !== "";
+  const hasYLabel = yLabelText !== undefined && yLabelText !== "";
+
   const allAreas = useMemo(() => {
     return series.every((s) => {
       return s.renderAs === "area";
@@ -130,7 +135,12 @@ export function AreaChart({
       <ResponsiveContainer width="100%" height="100%">
         <RechartsAreaChart
           data={data as Array<Record<string, unknown>>}
-          margin={{ top: 10, right: 10, bottom: 0, left: 0 }}
+          margin={{
+            top: 10,
+            right: 10,
+            bottom: hasXLabel ? 30 : 0,
+            left: hasYLabel ? 10 : 0,
+          }}
           stackOffset={stackOffset}
         >
           <defs>
@@ -168,6 +178,16 @@ export function AreaChart({
               interval="preserveStartEnd"
               minTickGap={5}
               {...styleProps.xAxisProps}
+              label={
+                hasXLabel ?
+                  {
+                    value: xLabelText,
+                    position: "insideBottom",
+                    offset: -10,
+                    fill: chartStyle?.xAxis?.labelColor,
+                  }
+                : undefined
+              }
             />
           : null}
           {styleProps.withYAxis !== false ?
@@ -176,6 +196,16 @@ export function AreaChart({
               stroke=""
               tickLine={false}
               {...styleProps.yAxisProps}
+              label={
+                hasYLabel ?
+                  {
+                    value: yLabelText,
+                    angle: -90,
+                    position: "insideLeft",
+                    fill: chartStyle?.yAxis?.labelColor,
+                  }
+                : undefined
+              }
             />
           : null}
           {withLegend ?

--- a/src/lib/ui/viz/ScatterChart.tsx
+++ b/src/lib/ui/viz/ScatterChart.tsx
@@ -47,16 +47,55 @@ export function ScatterChart({
 
   const isSingleSeries = series.length === 1;
   const firstSeries = series[0];
+  const xLabel =
+    isSingleSeries && firstSeries !== undefined ? firstSeries.xKey : undefined;
+  const yLabel =
+    isSingleSeries && firstSeries !== undefined ? firstSeries.key : undefined;
 
   return (
     <MantineScatterChart
       h={height}
       data={scatterSeries}
       dataKey={{ x: "x", y: "y" }}
-      xAxisLabel={isSingleSeries && firstSeries ? firstSeries.xKey : undefined}
-      yAxisLabel={isSingleSeries && firstSeries ? firstSeries.key : undefined}
       withLegend
       valueFormatter={formatChartNumber}
+      xAxisProps={
+        xLabel !== undefined
+          ? {
+              label: {
+                value: xLabel,
+                position: "insideBottom",
+                offset: -15,
+                fontSize: 12,
+              },
+            }
+          : undefined
+      }
+      yAxisProps={
+        yLabel !== undefined
+          ? {
+              width: 80,
+              label: {
+                value: yLabel,
+                angle: -90,
+                position: "insideLeft",
+                offset: -15,
+                fontSize: 12,
+              },
+            }
+          : undefined
+      }
+      scatterChartProps={
+        xLabel !== undefined || yLabel !== undefined
+          ? {
+              margin: {
+                bottom: xLabel !== undefined ? 40 : undefined,
+                left: yLabel !== undefined ? 30 : undefined,
+                right: yLabel !== undefined ? 5 : undefined,
+              },
+            }
+          : undefined
+      }
     />
   );
 }

--- a/src/lib/ui/viz/ScatterChart.tsx
+++ b/src/lib/ui/viz/ScatterChart.tsx
@@ -60,41 +60,41 @@ export function ScatterChart({
       withLegend
       valueFormatter={formatChartNumber}
       xAxisProps={
-        xLabel !== undefined
-          ? {
-              label: {
-                value: xLabel,
-                position: "insideBottom",
-                offset: -15,
-                fontSize: 12,
-              },
-            }
-          : undefined
+        xLabel !== undefined ?
+          {
+            label: {
+              value: xLabel,
+              position: "insideBottom",
+              offset: -15,
+              fontSize: 12,
+            },
+          }
+        : undefined
       }
       yAxisProps={
-        yLabel !== undefined
-          ? {
-              width: 80,
-              label: {
-                value: yLabel,
-                angle: -90,
-                position: "insideLeft",
-                offset: -15,
-                fontSize: 12,
-              },
-            }
-          : undefined
+        yLabel !== undefined ?
+          {
+            width: 80,
+            label: {
+              value: yLabel,
+              angle: -90,
+              position: "insideLeft",
+              offset: -15,
+              fontSize: 12,
+            },
+          }
+        : undefined
       }
       scatterChartProps={
-        xLabel !== undefined || yLabel !== undefined
-          ? {
-              margin: {
-                bottom: xLabel !== undefined ? 40 : undefined,
-                left: yLabel !== undefined ? 30 : undefined,
-                right: yLabel !== undefined ? 5 : undefined,
-              },
-            }
-          : undefined
+        xLabel !== undefined || yLabel !== undefined ?
+          {
+            margin: {
+              bottom: xLabel !== undefined ? 40 : undefined,
+              left: yLabel !== undefined ? 30 : undefined,
+              right: yLabel !== undefined ? 5 : undefined,
+            },
+          }
+        : undefined
       }
     />
   );

--- a/src/lib/ui/viz/SeriesRenderer.props.test.tsx
+++ b/src/lib/ui/viz/SeriesRenderer.props.test.tsx
@@ -175,16 +175,17 @@ describe("BarChart — chart-level settings reach Mantine", () => {
     expect(props.withYAxis).toBe(false);
   });
 
-  it("applies axis label color via xAxisProps.label.fill", () => {
+  it("applies axis label via xAxisLabel and color via styles.axisLabel.fill", () => {
     renderBar({
       ...BAR_BASELINE,
       chartStyle: { xAxis: { label: "Month", labelColor: "#ff0000" } },
     });
     const props = lastProps<{
-      xAxisProps?: { label?: { value?: string; fill?: string } };
+      xAxisLabel?: string;
+      styles?: { axisLabel?: { fill?: string } };
     }>(mantineBarChartMock);
-    expect(props.xAxisProps?.label?.value).toBe("Month");
-    expect(props.xAxisProps?.label?.fill).toBe("#ff0000");
+    expect(props.xAxisLabel).toBe("Month");
+    expect(props.styles?.axisLabel?.fill).toBe("#ff0000");
   });
 
   it("applies tick color via xAxisProps.tick.fill", () => {

--- a/src/lib/ui/viz/applyChartStyle.ts
+++ b/src/lib/ui/viz/applyChartStyle.ts
@@ -1,5 +1,6 @@
 import { formatChartNumber } from "@/lib/ui/viz/formatChartNumber";
 import type { ChartStyle } from "$/models/vizs/ChartStyle";
+import type { CSSProperties } from "react";
 import type {
   CartesianGridProps,
   LegendProps,
@@ -8,7 +9,6 @@ import type {
 } from "recharts";
 
 const DEFAULT_TICK_FONT_SIZE = 12;
-const DEFAULT_AXIS_LABEL_OFFSET = -10;
 
 /**
  * Default Y-axis width that fits compact-formatted ticks (`1.5M`, `999.99B`)
@@ -36,6 +36,22 @@ export type ChartStyleProps = {
   gridProps?: Omit<CartesianGridProps, "ref">;
   gridColor?: string;
   legendProps?: Omit<LegendProps, "ref">;
+  /**
+   * Mantine-native prop: triggers automatic bottom-margin so the label is
+   * visible.
+   */
+  xAxisLabel?: string;
+  /**
+   * Mantine-native prop: triggers automatic left-margin so the label is
+   * visible.
+   */
+  yAxisLabel?: string;
+  /**
+   * Passed to Mantine's `styles` prop. Used to apply axis label color via the
+   * `axisLabel` slot (shared by both x and y labels). X-axis labelColor takes
+   * priority over y-axis when both are set.
+   */
+  styles?: Partial<Record<string, CSSProperties>>;
 };
 
 /**
@@ -62,14 +78,6 @@ export function applyChartStyle(
       fontSize: DEFAULT_TICK_FONT_SIZE,
     };
   }
-  if (xAxisStyle?.label !== undefined && xAxisStyle.label !== "") {
-    xAxisProps.label = {
-      value: xAxisStyle.label,
-      position: "insideBottom",
-      offset: DEFAULT_AXIS_LABEL_OFFSET,
-      fill: xAxisStyle.labelColor,
-    };
-  }
 
   const yAxisProps: Omit<YAxisProps, "ref"> = {
     tickFormatter: _formatYAxisTick,
@@ -79,14 +87,6 @@ export function applyChartStyle(
     yAxisProps.tick = {
       fill: yAxisStyle.tickColor,
       fontSize: DEFAULT_TICK_FONT_SIZE,
-    };
-  }
-  if (yAxisStyle?.label !== undefined && yAxisStyle.label !== "") {
-    yAxisProps.label = {
-      value: yAxisStyle.label,
-      angle: -90,
-      position: "insideLeft",
-      fill: yAxisStyle.labelColor,
     };
   }
 
@@ -113,6 +113,21 @@ export function applyChartStyle(
       : "center",
   };
 
+  const xAxisLabel =
+    xAxisStyle?.label !== undefined && xAxisStyle.label !== ""
+      ? xAxisStyle.label
+      : undefined;
+  const yAxisLabel =
+    yAxisStyle?.label !== undefined && yAxisStyle.label !== ""
+      ? yAxisStyle.label
+      : undefined;
+
+  const axisLabelColor = xAxisStyle?.labelColor ?? yAxisStyle?.labelColor;
+  const styles: Partial<Record<string, CSSProperties>> | undefined =
+    axisLabelColor !== undefined
+      ? { axisLabel: { fill: axisLabelColor } }
+      : undefined;
+
   return {
     withXAxis: !(xAxisStyle?.hide ?? false),
     withYAxis: !(yAxisStyle?.hide ?? false),
@@ -121,5 +136,8 @@ export function applyChartStyle(
     gridProps,
     gridColor: gridStyle?.color,
     legendProps,
+    xAxisLabel,
+    yAxisLabel,
+    styles,
   };
 }

--- a/src/lib/ui/viz/applyChartStyle.ts
+++ b/src/lib/ui/viz/applyChartStyle.ts
@@ -114,19 +114,19 @@ export function applyChartStyle(
   };
 
   const xAxisLabel =
-    xAxisStyle?.label !== undefined && xAxisStyle.label !== ""
-      ? xAxisStyle.label
-      : undefined;
+    xAxisStyle?.label !== undefined && xAxisStyle.label !== "" ?
+      xAxisStyle.label
+    : undefined;
   const yAxisLabel =
-    yAxisStyle?.label !== undefined && yAxisStyle.label !== ""
-      ? yAxisStyle.label
-      : undefined;
+    yAxisStyle?.label !== undefined && yAxisStyle.label !== "" ?
+      yAxisStyle.label
+    : undefined;
 
   const axisLabelColor = xAxisStyle?.labelColor ?? yAxisStyle?.labelColor;
   const styles: Partial<Record<string, CSSProperties>> | undefined =
-    axisLabelColor !== undefined
-      ? { axisLabel: { fill: axisLabelColor } }
-      : undefined;
+    axisLabelColor !== undefined ?
+      { axisLabel: { fill: axisLabelColor } }
+    : undefined;
 
   return {
     withXAxis: !(xAxisStyle?.hide ?? false),


### PR DESCRIPTION
**Bugs fixed**:
1. **Axis titles not displaying** - Custom axis titles (e.g. "Countries", "Death Counts") were cut off or completely invisible in Bar, Line, Composite, and Area charts across Data Explorer, Dashboard editor, and Dashboard preview.
2. **Axis label color not customizable** - Setting a custom color for axis labels had no effect in Bar, Line, Composite, and Area charts.
3. **Scatter plot label overlap** - X-axis and Y-axis labels in scatter plots overlapped with the axis tick numbers, making both hard to read.

**Root causes & fixes**:
- **Bar/Line/Composite**: `applyChartStyle.ts` was setting labels via Recharts-level `xAxisProps.label`/`yAxisProps.label` instead of Mantine's native `xAxisLabel`/`yAxisLabel` props. Mantine only reserves margin space for labels when using its native props. Switched to native props so Mantine handles margins automatically. Color is now applied via `styles.axisLabel.fill`.
- **Area chart**: Hardcoded `margin: { bottom: 0, left: 0 }` left no room for labels. Now dynamically sets margin when labels are present, and applies color directly via Recharts `label` config.
- **Scatter plot**: Mantine's hardcoded label offsets caused overlap with tick numbers. Bypassed Mantine's native label props entirely and rendered custom `<Label>` elements via `xAxisProps`/`yAxisProps` with corrected offsets (`-15`).

**Known limitation**: Mantine's `axisLabel` style slot is shared between X and Y axis labels, if both axes have different label colors set, only the X-axis color is applied to both. This is a Mantine API constraint.

**Testing**: Verified across Bar, Line, Composite, Area, and Scatter charts in Data Explorer, Dashboard editor, and Dashboard preview. Confirmed no regression when no axis labels are set.