### PR TITLE
fix: stack column selectors vertically in Bubble Chart and Scatter Plot settings to prevent overflow

### DIFF
--- a/src/components/VisualizationContainer/VizSettingsForm/BubbleSeriesFieldset.tsx
+++ b/src/components/VisualizationContainer/VizSettingsForm/BubbleSeriesFieldset.tsx
@@ -124,12 +124,8 @@ export function BubbleSeriesFieldset({
                 padding="sm"
               >
                 <Stack gap="xs">
-                  <Group justify="space-between" wrap="nowrap">
-                    <Group
-                      gap="xs"
-                      style={{ flex: 1, minWidth: 0 }}
-                      wrap="nowrap"
-                    >
+                  <Group justify="space-between" wrap="nowrap" align="flex-start">
+                    <Stack gap="xs" style={{ flex: 1, minWidth: 0 }}>
                       <Select
                         allowDeselect={false}
                         label={t`X column`}
@@ -146,7 +142,6 @@ export function BubbleSeriesFieldset({
                             updateAt(idx, { xKey: next });
                           }
                         }}
-                        style={{ flex: 1 }}
                       />
                       <Select
                         allowDeselect={false}
@@ -164,7 +159,6 @@ export function BubbleSeriesFieldset({
                             updateAt(idx, { key: next });
                           }
                         }}
-                        style={{ flex: 1 }}
                       />
                       <Select
                         allowDeselect={false}
@@ -182,9 +176,8 @@ export function BubbleSeriesFieldset({
                             updateAt(idx, { sizeKey: next });
                           }
                         }}
-                        style={{ flex: 1 }}
                       />
-                    </Group>
+                    </Stack>
                     <ActionIcon
                       aria-label={t`Remove series`}
                       variant="subtle"

--- a/src/components/VisualizationContainer/VizSettingsForm/BubbleSeriesFieldset.tsx
+++ b/src/components/VisualizationContainer/VizSettingsForm/BubbleSeriesFieldset.tsx
@@ -124,7 +124,11 @@ export function BubbleSeriesFieldset({
                 padding="sm"
               >
                 <Stack gap="xs">
-                  <Group justify="space-between" wrap="nowrap" align="flex-start">
+                  <Group
+                    justify="space-between"
+                    wrap="nowrap"
+                    align="flex-start"
+                  >
                     <Stack gap="xs" style={{ flex: 1, minWidth: 0 }}>
                       <Select
                         allowDeselect={false}

--- a/src/components/VisualizationContainer/VizSettingsForm/PairSeriesFieldset.tsx
+++ b/src/components/VisualizationContainer/VizSettingsForm/PairSeriesFieldset.tsx
@@ -119,7 +119,11 @@ export function PairSeriesFieldset({
                 padding="sm"
               >
                 <Stack gap="xs">
-                  <Group justify="space-between" wrap="nowrap" align="flex-start">
+                  <Group
+                    justify="space-between"
+                    wrap="nowrap"
+                    align="flex-start"
+                  >
                     <Stack gap="xs" style={{ flex: 1, minWidth: 0 }}>
                       <Select
                         allowDeselect={false}

--- a/src/components/VisualizationContainer/VizSettingsForm/PairSeriesFieldset.tsx
+++ b/src/components/VisualizationContainer/VizSettingsForm/PairSeriesFieldset.tsx
@@ -119,12 +119,8 @@ export function PairSeriesFieldset({
                 padding="sm"
               >
                 <Stack gap="xs">
-                  <Group justify="space-between" wrap="nowrap">
-                    <Group
-                      gap="xs"
-                      style={{ flex: 1, minWidth: 0 }}
-                      wrap="nowrap"
-                    >
+                  <Group justify="space-between" wrap="nowrap" align="flex-start">
+                    <Stack gap="xs" style={{ flex: 1, minWidth: 0 }}>
                       <Select
                         allowDeselect={false}
                         label={t`X column`}
@@ -141,7 +137,6 @@ export function PairSeriesFieldset({
                             updateAt(idx, { xKey: next });
                           }
                         }}
-                        style={{ flex: 1 }}
                       />
                       <Select
                         allowDeselect={false}
@@ -159,9 +154,8 @@ export function PairSeriesFieldset({
                             updateAt(idx, { key: next });
                           }
                         }}
-                        style={{ flex: 1 }}
                       />
-                    </Group>
+                    </Stack>
                     <ActionIcon
                       aria-label={t`Remove series`}
                       variant="subtle"

--- a/src/views/WorkspaceSettingsPage/WorkspaceBillingView/planUtils.ts
+++ b/src/views/WorkspaceSettingsPage/WorkspaceBillingView/planUtils.ts
@@ -166,10 +166,11 @@ export function makeSubscriptionPlanFromPolarProduct(
     return undefined;
   }
 
-  // Free plans are native (no Polar checkout) so we don't need a Polar price
-  // to render the Free card. Polar has deprecated `LegacyRecurringProductPriceFree`
-  // and now ships some free recurring products without any price object, which
-  // would otherwise cause the product to be dropped below.
+  // Free plans are native (no Polar checkout) so we don't need a Polar
+  // price to render the Free card. Polar has deprecated
+  // `LegacyRecurringProductPriceFree` and now ships some free recurring
+  // products without any price object, which would otherwise cause the
+  // product to be dropped below.
   if (featurePlan.type === "free") {
     return {
       priceType: "free" as const,


### PR DESCRIPTION
**Bug**: In the Visualization Settings panel, when Visualization Type is set to Bubble Chart or Scatter Plot, the X column, Y column, and Size column selector labels and selected values were truncated/cut off. The panel has a fixed width (340px), and with 3 selects (Bubble Chart) or 2 selects (Scatter Plot) laid out horizontally, there wasn't enough room for labels or values to display fully.

**Fix**: Replaced the horizontal `Group` layout with a vertical `Stack` in `BubbleSeriesFieldset.tsx` and `PairSeriesFieldset.tsx`, matching the existing pattern already used in `PieChartForm.tsx` and `FunnelChartForm.tsx`. Each select now gets the full width of the card interior (~216px), eliminating truncation.

**Also included**: Fixed a pre-existing `max-len` lint error (comment length) in `planUtils.ts` unrelated to this change but caught during testing.

**Testing**: Verified Bubble Chart and Scatter Plot selects show full labels and values in Data Explorer and Dashboard editor. Confirmed trash icon stays correctly positioned.