### PR TITLE
fix: use createUsePuck selector and remove nested form causing hydration error

### DIFF
--- a/src/views/DashboardApp/AvaPage/pfields/VizConfigPField/VizConfigPField.test.tsx
+++ b/src/views/DashboardApp/AvaPage/pfields/VizConfigPField/VizConfigPField.test.tsx
@@ -14,18 +14,20 @@ const TEST_DASHBOARD_ID = "00000000-0000-4000-8000-000000000002" as DashboardId;
 
 vi.mock("@puckeditor/core", () => {
   return {
-    usePuck: () => {
-      return {
-        selectedItem: {
-          props: {
-            id: "viz-block",
-            nlQuery: {
-              prompt: "find data",
-              rawSql: "SELECT * FROM foo",
-              generations: [],
+    createUsePuck: () => {
+      return (selector: (state: unknown) => unknown) => {
+        return selector({
+          selectedItem: {
+            props: {
+              id: "viz-block",
+              nlQuery: {
+                prompt: "find data",
+                rawSql: "SELECT * FROM foo",
+                generations: [],
+              },
             },
           },
-        },
+        });
       };
     },
   };

--- a/src/views/DashboardApp/AvaPage/pfields/VizConfigPField/VizConfigPField.tsx
+++ b/src/views/DashboardApp/AvaPage/pfields/VizConfigPField/VizConfigPField.tsx
@@ -1,6 +1,6 @@
 import { Trans } from "@lingui/react/macro";
 import { Box, Text } from "@mantine/core";
-import { usePuck } from "@puckeditor/core";
+import { createUsePuck } from "@puckeditor/core";
 import { DashboardId } from "$/models/Dashboard/Dashboard.types";
 import { StructuredQuery } from "$/models/queries/StructuredQuery/StructuredQuery";
 import { Workspace } from "$/models/Workspace/Workspace";
@@ -9,6 +9,8 @@ import { VizSettingsFormBody } from "@/components/VisualizationContainer/VizSett
 import { NLQuery } from "@/views/DashboardApp/AvaPage/pfields/NLQueryPField/NLQueryPField";
 import { useDataQuery } from "@/views/DataExplorerApp/useDataQuery";
 import type { VizConfig } from "$/models/vizs/VizConfig/VizConfig.types";
+
+const usePuckSelector = createUsePuck();
 
 type Props = {
   /** Current viz config. */
@@ -43,7 +45,9 @@ export function VizConfigPField({
   workspaceId,
   dashboardId,
 }: Props): JSX.Element {
-  const { selectedItem } = usePuck();
+  const selectedItem = usePuckSelector((state) => {
+    return state.selectedItem;
+  });
   const rawSql =
     (selectedItem?.props as { nlQuery?: NLQuery } | undefined)?.nlQuery
       ?.rawSql ?? "";

--- a/src/views/DataExplorerApp/QueryForm/ManualQueryForm.tsx
+++ b/src/views/DataExplorerApp/QueryForm/ManualQueryForm.tsx
@@ -192,7 +192,7 @@ function ManualQueryFormView({
   };
 
   return (
-    <form>
+    <div>
       <Stack px="sm">
         {pendingChange ?
           <Alert
@@ -368,6 +368,6 @@ function ManualQueryFormView({
           </Group>
         </Fieldset>
       </Stack>
-    </form>
+    </div>
   );
 }


### PR DESCRIPTION
**Fix 1: usePuck performance warning**

`VizConfigPField.tsx` was calling `usePuck()` without a selector, causing the component to re-render on every Puck state change instead of only when `selectedItem` changes. The installed `@puckeditor/core` version doesn't support a selector argument directly on `usePuck()`, switched to `createUsePuck()` called at module level, with `usePuckSelector((state) => state.selectedItem)` used inside the component.

**Fix 2: Nested `<form>` hydration error**

Puck wraps all custom fields in a `<form>` internally. `ManualQueryFormView` (originally written for standalone Data Explorer) also rendered a `<form>` as its root, causing an invalid `<form>` → `<form>` nesting when rendered inside the dashboard editor's Puck sidebar. This triggered a React hydration warning on first DataViz block selection: "In HTML, `<form>` cannot be a descendant of `<form>`."

The `<form>` in `ManualQueryFormView` had no `onSubmit` handler, all buttons already used `type="button"` and interactions went through `onChange` callbacks. Changed the root element from `<form>` to `<div>` since it was purely structural.

**Testing**: Verified `usePuck` warning no longer appears in console. Verified nested form error no longer appears on first DataViz block click after fresh page load. Confirmed Manual Query functionality (typing, column selection, filters) still works correctly in both Dashboard editor and Data Explorer.